### PR TITLE
Bug fix: formats used the same disk path with different queues.

### DIFF
--- a/Haneke/Cache.swift
+++ b/Haneke/Cache.swift
@@ -148,10 +148,29 @@ public class Cache<T : DataConvertible where T.Result == T, T : DataRepresentabl
     var formats : [String : (Format<T>, NSCache, DiskCache)] = [:]
     
     public func addFormat(format : Format<T>) {
-        let name = self.name
+        let name = format.name
+        let formatPath = self.formatPath(formatName: name)
         let memoryCache = NSCache()
-        let diskCache = DiskCache(name: name, capacity : format.diskCapacity)
-        self.formats[format.name] = (format, memoryCache, diskCache)
+        let diskCache = DiskCache(path: formatPath, capacity : format.diskCapacity)
+        self.formats[name] = (format, memoryCache, diskCache)
+    }
+    
+    // MARK: Internal
+    
+    lazy var cachePath : String = {
+        let basePath = DiskCache.basePath()
+        let cachePath = basePath.stringByAppendingPathComponent(self.name)
+        return cachePath
+    }()
+    
+    func formatPath(#formatName : String) -> String {
+        let formatPath = self.cachePath.stringByAppendingPathComponent(formatName)
+        var error : NSError? = nil
+        let success = NSFileManager.defaultManager().createDirectoryAtPath(formatPath, withIntermediateDirectories: true, attributes: nil, error: &error)
+        if (!success) {
+            NSLog("Failed to create directory \(formatPath) with error \(error!)")
+        }
+        return formatPath
     }
     
     // MARK: Private

--- a/Haneke/DiskCache.swift
+++ b/Haneke/DiskCache.swift
@@ -18,7 +18,7 @@ public class DiskCache {
         return basePath
     }
     
-    public let name : String
+    public let path : String
 
     public var size : UInt64 = 0
 
@@ -30,25 +30,14 @@ public class DiskCache {
         }
     }
 
-    public lazy var cachePath : String = {
-        let basePath = DiskCache.basePath()
-        let cachePath = basePath.stringByAppendingPathComponent(self.name)
-        var error : NSError? = nil
-        let success = NSFileManager.defaultManager().createDirectoryAtPath(cachePath, withIntermediateDirectories: true, attributes: nil, error: &error)
-        if (!success) {
-            NSLog("Failed to create directory \(cachePath) with error \(error!)")
-        }
-        return cachePath
-    }()
-
     public lazy var cacheQueue : dispatch_queue_t = {
-        let queueName = Haneke.Domain + "." + self.name
+        let queueName = Haneke.Domain + "." + self.path.lastPathComponent
         let cacheQueue = dispatch_queue_create(queueName, nil)
         return cacheQueue
     }()
     
-    public init(name : String, capacity : UInt64 = UINT64_MAX) {
-        self.name = name
+    public init(path : String, capacity : UInt64 = UINT64_MAX) {
+        self.path = path
         self.capacity = capacity
         dispatch_async(self.cacheQueue, {
             self.calculateSize()
@@ -98,7 +87,7 @@ public class DiskCache {
     
     public func removeAllData() {
         let fileManager = NSFileManager.defaultManager()
-        let cachePath = self.cachePath
+        let cachePath = self.path
         dispatch_async(cacheQueue, {
             var error: NSError? = nil
             if let contents = fileManager.contentsOfDirectoryAtPath(cachePath, error: &error) as? [String] {
@@ -129,8 +118,8 @@ public class DiskCache {
     public func pathForKey(key : String) -> String {
         var escapedFilename = key.escapedFilename()
         let filename = countElements(escapedFilename) < Int(NAME_MAX) ? escapedFilename : key.MD5Filename()
-        let path = self.cachePath.stringByAppendingPathComponent(filename)
-        return path
+        let keyPath = self.path.stringByAppendingPathComponent(filename)
+        return keyPath
     }
     
     // MARK: Private
@@ -138,7 +127,7 @@ public class DiskCache {
     private func calculateSize() {
         let fileManager = NSFileManager.defaultManager()
         size = 0
-        let cachePath = self.cachePath
+        let cachePath = self.path
         var error : NSError?
         if let contents = fileManager.contentsOfDirectoryAtPath(cachePath, error: &error) as? [String] {
             for pathComponent in contents {
@@ -158,7 +147,7 @@ public class DiskCache {
         if self.size <= self.capacity { return }
         
         let fileManager = NSFileManager.defaultManager()
-        let cachePath = self.cachePath
+        let cachePath = self.path
         fileManager.enumerateContentsOfDirectoryAtPath(cachePath, orderedByProperty: NSURLContentModificationDateKey, ascending: true) { (URL : NSURL, _, inout stop : Bool) -> Void in
             
             if let path = URL.path {

--- a/HanekeTests/CacheTests.swift
+++ b/HanekeTests/CacheTests.swift
@@ -36,11 +36,42 @@ class CacheTests: XCTestCase {
         weak var sut = Cache<UIImage>(name: self.name)
     }
     
+    // MARK: cachePath
+    
+    func testCachePath() {
+        let expectedCachePath = DiskCache.basePath().stringByAppendingPathComponent(sut.name)
+        XCTAssertEqual(sut.cachePath, expectedCachePath)
+    }
+    
+    // MARK: formatPath
+    
+    func testFormatPath() {
+        let formatName = self.name
+        let expectedFormatPath = sut.cachePath.stringByAppendingPathComponent(formatName)
+        
+        let formatPath = sut.formatPath(formatName: formatName)
+        
+        XCTAssertEqual(formatPath, expectedFormatPath)
+    }
+    
+    func testFormatPath_WithEmptyName() {
+        let formatName = ""
+        let expectedFormatPath = sut.cachePath.stringByAppendingPathComponent(formatName)
+        
+        let formatPath = sut.formatPath(formatName: formatName)
+        
+        XCTAssertEqual(formatPath, expectedFormatPath)
+    }
+
+    // MARK: addFormat
+    
     func testAddFormat() {
         let format = Format<UIImage>(name: self.name)
         
         sut.addFormat(format)
     }
+
+    // MARK: set
     
     func testSet_WithDefaultFormat () {
         let image = UIImage.imageWithColor(UIColor.greenColor())
@@ -122,6 +153,8 @@ class CacheTests: XCTestCase {
         }
         self.waitForExpectationsWithTimeout(1, nil)
     }
+    
+    // MARK: fetch
     
     func testFetch_WithKey_OnSuccess () {
         let image = UIImage.imageWithColor(UIColor.cyanColor())
@@ -355,6 +388,8 @@ class CacheTests: XCTestCase {
         self.waitForExpectationsWithTimeout(1, nil)
     }
     
+    // MARK: remove
+    
     func testRemove_Existing() {
         let key = self.name
         sut.set(value: UIImage.imageWithColor(UIColor.greenColor()), key: key)
@@ -430,6 +465,8 @@ class CacheTests: XCTestCase {
     func testRemove_WithInexistingKey() {
         sut.remove(key: self.name)
     }
+    
+    // MARK: removeAll
     
     func testRemoveAll_One() {
         let key = self.name

--- a/HanekeTests/DiskCacheTests.swift
+++ b/HanekeTests/DiskCacheTests.swift
@@ -13,13 +13,20 @@ class DiskCacheTests: XCTestCase {
 
     var sut : DiskCache!
     
+    lazy var diskCachePath : String = {
+        let diskCachePath =  DiskCache.basePath().stringByAppendingPathComponent(self.name)
+        NSFileManager.defaultManager().createDirectoryAtPath(diskCachePath, withIntermediateDirectories: true, attributes: nil, error: nil)
+        return diskCachePath
+    }()
+    
     override func setUp() {
         super.setUp()
-        sut = DiskCache(name: self.name)
+        sut = DiskCache(path:diskCachePath)
     }
     
     override func tearDown() {
         sut.removeAllData()
+        NSFileManager.defaultManager().removeItemAtPath(diskCachePath, error: nil)
         super.tearDown()
     }
     
@@ -30,21 +37,19 @@ class DiskCacheTests: XCTestCase {
     }
     
     func testInit() {
-        let name = self.name
-
-        let sut = DiskCache(name: name)
+        let sut = DiskCache(path:diskCachePath)
         
-        XCTAssertEqual(sut.name, name)
+        XCTAssertEqual(sut.path, diskCachePath)
         XCTAssertEqual(sut.size, 0)
     }
     
     func testInitWithOneFile() {
         let name = self.name
-        let directory = DiskCache(name: name).cachePath
+        let path = diskCachePath
         let expectedSize = 8
-        self.writeDataWithLength(expectedSize, directory: directory)
+        self.writeDataWithLength(expectedSize, directory: path)
         
-        let sut = DiskCache(name: name)
+        let sut = DiskCache(path: path)
         
         dispatch_sync(sut.cacheQueue, {
             XCTAssertEqual(sut.size, UInt64(expectedSize))
@@ -53,12 +58,12 @@ class DiskCacheTests: XCTestCase {
     
     func testInitWithTwoFiles() {
         let name = self.name
-        let directory = DiskCache(name: name).cachePath
+        let directory = diskCachePath
         let lengths = [4, 7]
         self.writeDataWithLength(lengths[0], directory: directory)
         self.writeDataWithLength(lengths[1], directory: directory)
         
-        let sut = DiskCache(name: name)
+        let sut = DiskCache(path: directory)
         
         dispatch_sync(sut.cacheQueue, {
             XCTAssertEqual(sut.size, UInt64(lengths.reduce(0, +)))
@@ -67,10 +72,10 @@ class DiskCacheTests: XCTestCase {
     
     func testInitCapacityZeroOneExistingFile() {
         let name = self.name
-        let directory = DiskCache(name: name).cachePath
+        let directory = diskCachePath
         let path = self.writeDataWithLength(1, directory: directory)
         
-        let sut = DiskCache(name: name, capacity : 0)
+        let sut = DiskCache(path: directory, capacity : 0)
         
         dispatch_sync(sut.cacheQueue, {
             XCTAssertEqual(sut.size, 0)
@@ -80,11 +85,11 @@ class DiskCacheTests: XCTestCase {
     
     func testInitCapacityZeroTwoExistingFiles() {
         let name = self.name
-        let directory = DiskCache(name: name).cachePath
+        let directory = diskCachePath
         let path1 = self.writeDataWithLength(1, directory: directory)
         let path2 = self.writeDataWithLength(2, directory: directory)
         
-        let sut = DiskCache(name: name, capacity : 0)
+        let sut = DiskCache(path: directory, capacity : 0)
         
         dispatch_sync(sut.cacheQueue, {
             XCTAssertEqual(sut.size, 0)
@@ -95,12 +100,12 @@ class DiskCacheTests: XCTestCase {
     
     func testInitLeastRecentlyUsedExistingFileDeleted() {
         let name = self.name
-        let directory = DiskCache(name: name).cachePath
+        let directory = diskCachePath
         let path1 = self.writeDataWithLength(1, directory: directory)
         let path2 = self.writeDataWithLength(1, directory: directory)
         NSFileManager.defaultManager().setAttributes([NSFileModificationDate : NSDate.distantPast()], ofItemAtPath: path2, error: nil)
         
-        let sut = DiskCache(name: name, capacity : 1)
+        let sut = DiskCache(path: directory, capacity : 1)
         
         dispatch_sync(sut.cacheQueue, {
             XCTAssertEqual(sut.size, 1)
@@ -109,29 +114,8 @@ class DiskCacheTests: XCTestCase {
         })
     }
     
-    func testCachePath() {
-        let cachePath = DiskCache.basePath().stringByAppendingPathComponent(sut.name)
-        XCTAssertEqual(sut.cachePath, cachePath)
-        
-        let fileManager = NSFileManager.defaultManager()
-        var isDirectory: ObjCBool = ObjCBool(0)
-        XCTAssertTrue(fileManager.fileExistsAtPath(cachePath, isDirectory: &isDirectory))
-        XCTAssertTrue(isDirectory)
-    }
-    
-    func testCachePathEmtpyName() {
-        let sut = DiskCache(name: "")
-        let cachePath = DiskCache.basePath()
-        XCTAssertEqual(sut.cachePath, cachePath)
-        
-        let fileManager = NSFileManager.defaultManager()
-        var isDirectory: ObjCBool = ObjCBool(0)
-        XCTAssertTrue(fileManager.fileExistsAtPath(cachePath, isDirectory: &isDirectory))
-        XCTAssertTrue(isDirectory)
-    }
-    
     func testCacheQueue() {
-        let expectedLabel = Haneke.Domain + "." + sut.name
+        let expectedLabel = Haneke.Domain + "." + diskCachePath.lastPathComponent
 
         let label = String.stringWithUTF8String(dispatch_queue_get_label(sut.cacheQueue))!
 
@@ -243,7 +227,7 @@ class DiskCacheTests: XCTestCase {
     }
     
     func testSetDataControlCapacity() {
-        let sut = DiskCache(name: self.name, capacity:0)
+        let sut = DiskCache(path: diskCachePath, capacity:0)
         let key = self.name
         let path = sut.pathForKey(key)
         
@@ -465,21 +449,21 @@ class DiskCacheTests: XCTestCase {
     
     func testPathForKey_WithShortKey() {
         let key = "test"
-        let expectedPath = sut.cachePath.stringByAppendingPathComponent(key.escapedFilename())
+        let expectedPath = sut.path.stringByAppendingPathComponent(key.escapedFilename())
 
         XCTAssertEqual(sut.pathForKey(key), expectedPath)
     }
     
     func testPathForKey_WithShortKeyWithSpecialCharacters() {
         let key = "http://haneke.io"
-        let expectedPath = sut.cachePath.stringByAppendingPathComponent(key.escapedFilename())
+        let expectedPath = sut.path.stringByAppendingPathComponent(key.escapedFilename())
         
         XCTAssertEqual(sut.pathForKey(key), expectedPath)
     }
     
     func testPathForKey_WithLongKey() {
         let key = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam pretium id nibh a pulvinar. Integer id ex in tellus egestas placerat. Praesent ultricies libero ligula, et convallis ligula imperdiet eu. Sed gravida, turpis sed vulputate feugiat, metus nisl scelerisque diam, ac aliquet metus nisi rutrum ipsum. Nulla vulputate pretium dolor, a pellentesque nulla. Nunc pellentesque tortor porttitor, sollicitudin leo in, sollicitudin ligula. Cras malesuada orci at neque interdum elementum. Integer sed sagittis diam. Mauris non elit sed augue consequat feugiat. Nullam volutpat tortor eget tempus pretium. Sed pharetra sem vitae diam hendrerit, sit amet dapibus arcu interdum. Fusce egestas quam libero, ut efficitur turpis placerat eu. Sed velit sapien, aliquam sit amet ultricies a, bibendum ac nibh. Maecenas imperdiet, quam quis tincidunt sollicitudin, nunc tellus ornare ipsum, nec rhoncus nunc nisi a lacus."
-        let expectedPath = sut.cachePath.stringByAppendingPathComponent(key.MD5Filename())
+        let expectedPath = sut.path.stringByAppendingPathComponent(key.MD5Filename())
         
         XCTAssertEqual(sut.pathForKey(key), expectedPath)
     }


### PR DESCRIPTION
Solved by adding format name to the disk cache path. Refactored DiskCache and Cache so that DiskCache doesn't handle its own path and receives it from Cache instead.
