### PR TITLE
Fix cell reuse issue on UIKit categories, closes #120

### DIFF
--- a/Haneke/UIButton+Haneke.swift
+++ b/Haneke/UIButton+Haneke.swift
@@ -37,16 +37,13 @@ public extension UIButton {
     }
     
     public func hnk_setImageFromFetcher(fetcher : Fetcher<UIImage>, state : UIControlState = .Normal, placeholder : UIImage? = nil, format : Format<UIImage>? = nil, failure fail : ((NSError?) -> ())? = nil, success succeed : ((UIImage) -> ())? = nil){
+        self.setImage(placeholder, forState: state)
         self.hnk_cancelSetImage()
         self.hnk_imageFetcher = fetcher
         
         let didSetImage = self.hnk_fetchImageForFetcher(fetcher, state: state, format : format, failure: fail, success: succeed)
         
         if didSetImage { return }
-        
-        if let placeHolder = placeholder {
-            self.setImage(placeholder, forState: state)
-        }
     }
     
     public func hnk_cancelSetImage() {

--- a/Haneke/UIImageView+Haneke.swift
+++ b/Haneke/UIImageView+Haneke.swift
@@ -32,23 +32,14 @@ public extension UIImageView {
         self.hnk_setImageFromFetcher(fetcher, placeholder: placeholder, format: format, failure: fail, success: succeed)
     }
     
-    public func hnk_setImageFromFetcher(fetcher : Fetcher<UIImage>,
-        placeholder : UIImage? = nil,
-        format : Format<UIImage>? = nil,
-        failure fail : ((NSError?) -> ())? = nil,
-        success succeed : ((UIImage) -> ())? = nil) {
-
+    public func hnk_setImageFromFetcher(fetcher : Fetcher<UIImage>, placeholder : UIImage? = nil, format : Format<UIImage>? = nil, failure fail : ((NSError?) -> ())? = nil, success succeed : ((UIImage) -> ())? = nil) {
+        self.image = placeholder
         self.hnk_cancelSetImage()
-        
         self.hnk_fetcher = fetcher
         
-            let didSetImage = self.hnk_fetchImageForFetcher(fetcher, format: format, failure: fail, success: succeed)
+        let didSetImage = self.hnk_fetchImageForFetcher(fetcher, format: format, failure: fail, success: succeed)
         
         if didSetImage { return }
-     
-        if let placeholder = placeholder {
-            self.image = placeholder
-        }
     }
     
     public func hnk_cancelSetImage() {


### PR DESCRIPTION
This was happening on both UIKit categories. Setting the placeholder image (doesn't matter wether is nil or not) at the very first beggining addresses this.
