### PR TITLE
Avoid caching upscaled images in retina displays.

### DIFF
--- a/Haneke/Format.swift
+++ b/Haneke/Format.swift
@@ -75,15 +75,17 @@ public struct ImageResizer {
         }
         assert(self.size.width > 0 && self.size.height > 0, "Expected non-zero size. Use ScaleMode.None to avoid resizing.")
         
+        let scale = UIScreen.mainScreen().scale  // must check scale or scaled images could be upscaled in retina displays
+        
         // If does not allow to scale up the image
         if (!self.allowUpscaling) {
-            if (resizeToSize.width > image.size.width || resizeToSize.height > image.size.height) {
+            if (scale * resizeToSize.width > image.size.width || scale * resizeToSize.height > image.size.height) {
                 return image
             }
         }
         
         // Avoid unnecessary computations
-        if (resizeToSize.width == image.size.width && resizeToSize.height == image.size.height) {
+        if (scale * resizeToSize.width == image.size.width && scale * resizeToSize.height == image.size.height) {
             return image
         }
         

--- a/Haneke/UIImageView+Haneke.swift
+++ b/Haneke/UIImageView+Haneke.swift
@@ -14,7 +14,7 @@ public extension UIImageView {
         let viewSize = self.bounds.size
             assert(viewSize.width > 0 && viewSize.height > 0, "[\(reflect(self).summary) \(__FUNCTION__)]: UImageView size is zero. Set its frame, call sizeToFit or force layout first.")
             let scaleMode = self.hnk_scaleMode
-            return HanekeGlobals.UIKit.formatWithSize(viewSize, scaleMode: scaleMode)
+            return HanekeGlobals.UIKit.formatWithSize(viewSize, scaleMode: scaleMode, allowUpscaling: scaleMode == ImageResizer.ScaleMode.AspectFit || scaleMode == ImageResizer.ScaleMode.AspectFill ? false : true)
     }
     
     public func hnk_setImageFromURL(URL: NSURL, placeholder : UIImage? = nil, format : Format<UIImage>? = nil, failure fail : ((NSError?) -> ())? = nil, success succeed : ((UIImage) -> ())? = nil) {


### PR DESCRIPTION
I made two changes that may help reducing the disk space in the cache thus allowing the keep more images in the same space.
