### PR TITLE
Issue #115: Use main thread for CGBitmapContextCreate operation 

### DIFF
--- a/Haneke/Cache.swift
+++ b/Haneke/Cache.swift
@@ -198,7 +198,7 @@ public class Cache<T : DataConvertible where T.Result == T, T : DataRepresentabl
                 }
             }
         }) { data in
-            dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), {
+            dispatch_async(dispatch_get_main_queue(), {
                 var value = T.convertFromData(data)
                 if let value = value {
                     let descompressedValue = self.decompressedImageIfNeeded(value)


### PR DESCRIPTION
to avoid EXC_BAD_ACCESS at UIImage+Haneke.swift line 56.  Issue #115.