### PR TITLE
Remove from cache by URL

### DIFF
--- a/Haneke/Cache.swift
+++ b/Haneke/Cache.swift
@@ -122,6 +122,11 @@ public class Cache<T : DataConvertible where T.Result == T, T : DataRepresentabl
         }
     }
     
+    public func remove(#URL : NSURL, formatName : String = HanekeGlobals.Cache.OriginalFormatName) {
+        let key: String = HanekeGlobals.NetworkFetcher.keyFromUrl(URL)
+        self.remove(key: key, formatName: formatName)
+    }
+    
     public func removeAll() {
         for (_, (_, memoryCache, diskCache)) in self.formats {
             memoryCache.removeAllObjects()

--- a/Haneke/NetworkFetcher.swift
+++ b/Haneke/NetworkFetcher.swift
@@ -16,6 +16,10 @@ extension Haneke {
             case MissingData = -401
             case InvalidStatusCode = -402
         }
+        
+        public static func keyFromUrl(url: NSURL) -> String {
+            return url.absoluteString!
+        }
     }
 }
 
@@ -26,7 +30,7 @@ public class NetworkFetcher<T : DataConvertible> : Fetcher<T> {
     public init(URL : NSURL) {
         self.URL = URL
 
-        let key =  URL.absoluteString!
+        let key: String = HanekeGlobals.NetworkFetcher.keyFromUrl(URL)
         super.init(key: key)
     }
     


### PR DESCRIPTION
Following the docs, If I do
```swift
let cache = Shared.JSONCache
let cache = Haneke.sharedJSONCache
let formatName = "images"
let URL = NSURL(string: "https://api.github.com/users/haneke")!

cache.fetch(URL: URL, formatName: formatName).onSuccess { JSON in
   println(JSON.dictionary?["bio"])
}
```

and then to remove this entry from the cache, I would need to do:
```swift
let cacheKey = URL.absoluteString!
cache.remove(key: cacheKey, formatName: formatName)
```

so I think allowing to do:
```
cache.remove(URL: URL, formatName: formatName)
```
makes sense.

@hpique WDYT? 