### PR TITLE
Update LICENSE with filled copyright boilerplate

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -175,18 +175,10 @@ Apache License
 
    END OF TERMS AND CONDITIONS
 
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "{}"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright {yyyy} {name of copyright owner}
+   Copyright 2014 Hermes Pique (@hpique)
+             2014 Joan Romano (@joanromano)
+             2014 Luis Ascorbe (@lascorbe)
+             2014 Oriol Blanc (@oriolblanc)
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
I noticed the LICENSE file did not follow the instructions in the *APPENDIX: How to apply the Apache License to your work.*.

I removed the APPENDIX and added use the copyright information found in the License section of the  README.md
