### PR TITLE
Check if file exists before updating access time

### DIFF
--- a/Haneke/DiskCache.swift
+++ b/Haneke/DiskCache.swift
@@ -106,7 +106,7 @@ public class DiskCache {
         dispatch_async(cacheQueue, {
             let path = self.pathForKey(key)
             let fileManager = NSFileManager.defaultManager()
-            if (!self.updateDiskAccessDateAtPath(path) && !fileManager.fileExistsAtPath(path)){
+            if (!(fileManager.fileExistsAtPath(path) && self.updateDiskAccessDateAtPath(path))){
                 if let data = getData() {
                     self.setDataSync(data, key: key)
                 } else {


### PR DESCRIPTION
When using `Format<UIImage>(name: "original", diskCapacity: 0)` with a `diskCapacity` of zero to disable disk caching and only use a memory cache, an error was logged about not being able to update the access time, which is – in this case – not an error.

Switched the `if` statement around so it only tries updating the access time when the file exists.

Ran all tests, all green.