### PR TITLE
Batch setting & fetching keys

### DIFF
--- a/Haneke/Cache.swift
+++ b/Haneke/Cache.swift
@@ -78,9 +78,12 @@ public class Cache<T : DataConvertible where T.Result == T, T : DataRepresentabl
     public func set(#values : [String:T], formatName : String = HanekeGlobals.Cache.OriginalFormatName, success succeed : (([String:T]) -> ())? = nil) {
         let totalCount = values.count
         var setCount = 0
+        var setValues = [String:T]()
         for (key, value) in values {
-            self.set(value: value, key: key, formatName: formatName) { _ in
-                if(++setCount == totalCount) { succeed?(values) }
+            self.set(value: value, key: key, formatName: formatName) {
+                setValue in
+                setValues[key] = setValue
+                if(++setCount == totalCount) { succeed?(setValues) }
             }
         }
     }

--- a/Haneke/Cache.swift
+++ b/Haneke/Cache.swift
@@ -75,6 +75,16 @@ public class Cache<T : DataConvertible where T.Result == T, T : DataRepresentabl
         }
     }
     
+    public func set(#values : [String:T], formatName : String = HanekeGlobals.Cache.OriginalFormatName, success succeed : (([String:T]) -> ())? = nil) {
+        let totalCount = values.count
+        var setCount = 0
+        for (key, value) in values {
+            self.set(value: value, key: key, formatName: formatName) { _ in
+                if(++setCount == totalCount) { succeed?(values) }
+            }
+        }
+    }
+    
     public func fetch(#key : String, formatName : String = HanekeGlobals.Cache.OriginalFormatName, failure fail : Fetch<T>.Failer? = nil, success succeed : Fetch<T>.Succeeder? = nil) -> Fetch<T> {
         let fetch = Cache.buildFetch(failure: fail, success: succeed)
         if let (format, memoryCache, diskCache) = self.formats[formatName] {
@@ -107,7 +117,7 @@ public class Cache<T : DataConvertible where T.Result == T, T : DataRepresentabl
             if let value = value {
                 result[key] = value
             }
-            if(++fetchedCount >= keys.count) {
+            if(++fetchedCount == keys.count) {
                 mainFetch.succeed(result)
             }
         }

--- a/HanekeTests/CacheTests.swift
+++ b/HanekeTests/CacheTests.swift
@@ -116,6 +116,31 @@ class CacheTests: XCTestCase {
         // XCAssertThrows(sut.set(value: image, key: key, formatName : self.name))
     }
     
+    func testMultiSet() {
+        let dictionary:[String:String] = ["a" : "1", "b" : "2", "c" : "3"]
+        var dataDictionary = [String:NSData]()
+        for (key, value) in dictionary {
+            dataDictionary[key] = value.dataUsingEncoding(NSUTF8StringEncoding, allowLossyConversion: true)!
+        }
+        let sut = self.sut!
+        let format = Format<NSData>(name: self.name)
+        sut.addFormat(format)
+        let expectation = self.expectationWithDescription(self.name)
+        sut.set(values: dataDictionary, formatName:format.name) {
+            setDictionary in
+            XCTAssert(setDictionary == dataDictionary)
+            sut.fetch(key: "c", formatName: format.name) {
+                data in
+                let value = NSString(data: data, encoding: NSUTF8StringEncoding) as? String
+                XCTAssertNotNil(value)
+                XCTAssertEqual(value!, "3")
+                expectation.fulfill()
+            }
+            return
+        }
+        self.waitForExpectationsWithTimeout(1, handler: nil)
+    }
+    
     // MARK: fetch
     
     func testFetchOnSuccess_AfterSet_WithKey_ExpectSyncSuccess () {

--- a/README.md
+++ b/README.md
@@ -103,6 +103,33 @@ The above call will first attempt to fetch the required JSON from (in order) mem
 
 Further customization can be achieved by using [formats](#formats), [supporting additional types](#supporting-additional-types) or implementing [custom fetchers](#custom-fetchers).
 
+### Setting and fetching multiple keys
+
+Methods are included to set and fetch multiple keys, and run a callback once all are complete.
+
+To set multiple key/value pairs, pass a dictionary with the keys and values set to the values parameter. The callback will receive the dictionary of set values.
+
+```Swift
+let cache = Shared.stringCache
+let dictionary = ["one":"banana", "two":"apples"]
+cache.set(values: dictionary) {
+    setDictionary in
+    println(setDictionary)
+}
+```
+
+To fetch multiple keys, pass an array of keys. The success callback will be a dictionary of found key/value pairs, keys not found will not be present.
+
+```Swift
+let cache = Shared.stringCache
+let keys = ["one","two","three"]
+cache.fetch(keys: keys) {
+    foundDictionary in
+	//Will not have the key "three" present if it was not set
+    println(foundDictionary)
+}
+```
+
 ## Extra ♡ for images
 
 Need to cache and display images? Haneke provides convenience methods for `UIImageView` and `UIButton` with optimizations for `UITableView` and `UICollectionView` cell reuse. Images will be resized appropriately and cached in a shared cache.


### PR DESCRIPTION
This is an implementation of setting and fetching multiple keys at once, with a callback once all are complete. It relies on counting the task callbacks. It could be done synchronously as well.

Resolves #195