### PR TITLE
Killed the complex DataConvertible, DataRepresentable protocols..

### DIFF
--- a/Haneke.playground/section-1.swift
+++ b/Haneke.playground/section-1.swift
@@ -22,7 +22,7 @@ func example2() {
 /// Set and fetch data from the shared data cache
 func example3() {
     let cache = Shared.dataCache
-    let data = "SGVscCEgSSdtIHRyYXBwZWQgaW4gYSBCYXNlNjQgc3RyaW5nIQ==".asData()
+    let data = "SGVscCEgSSdtIHRyYXBwZWQgaW4gYSBCYXNlNjQgc3RyaW5nIQ==".toData()!
     
     cache.set(value: data, key: "secret")
     

--- a/Haneke/Cache.swift
+++ b/Haneke/Cache.swift
@@ -33,7 +33,7 @@ extension HanekeGlobals {
     
 }
 
-public class Cache<T : DataConvertible where T.Result == T, T : DataRepresentable> {
+public class Cache<T : DataLiteralConvertable> {
     
     let name : String
     
@@ -180,7 +180,7 @@ public class Cache<T : DataConvertible where T.Result == T, T : DataRepresentabl
         if let data = format.convertToData?(value) {
             return data
         }
-        return value.asData()
+        return value.toData()
     }
     
     private func fetchFromDiskCache(diskCache : DiskCache, key : String, memoryCache : NSCache, failure fail : ((NSError?) -> ())?, success succeed : (T) -> ()) {
@@ -197,8 +197,7 @@ public class Cache<T : DataConvertible where T.Result == T, T : DataRepresentabl
             }
         }) { data in
             dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), {
-                var value = T.convertFromData(data)
-                if let value = value {
+                if let value = T(data:(data as! T.DataLiteralType)) {
                     let descompressedValue = self.decompressedImageIfNeeded(value)
                     dispatch_async(dispatch_get_main_queue(), {
                         succeed(descompressedValue)
@@ -262,7 +261,7 @@ public class Cache<T : DataConvertible where T.Result == T, T : DataRepresentabl
     // MARK: Convenience fetch
     // Ideally we would put each of these in the respective fetcher file as a Cache extension. Unfortunately, this fails to link when using the framework in a project as of Xcode 6.1.
     
-    public func fetch(#key : String, @autoclosure(escaping) value getValue : () -> T.Result, formatName : String = HanekeGlobals.Cache.OriginalFormatName, success succeed : Fetch<T>.Succeeder? = nil) -> Fetch<T> {
+    public func fetch(#key : String, @autoclosure(escaping) value getValue : () -> T, formatName : String = HanekeGlobals.Cache.OriginalFormatName, success succeed : Fetch<T>.Succeeder? = nil) -> Fetch<T> {
         let fetcher = SimpleFetcher<T>(key: key, value: getValue)
         return self.fetch(fetcher: fetcher, formatName: formatName, success: succeed)
     }

--- a/Haneke/DiskFetcher.swift
+++ b/Haneke/DiskFetcher.swift
@@ -21,7 +21,7 @@ extension HanekeGlobals {
     
 }
 
-public class DiskFetcher<T : DataConvertible> : Fetcher<T> {
+public class DiskFetcher<T : DataLiteralConvertable> : Fetcher<T> {
     
     let path : String
     var cancelled = false
@@ -34,7 +34,7 @@ public class DiskFetcher<T : DataConvertible> : Fetcher<T> {
     
     // MARK: Fetcher
     
-    public override func fetch(failure fail : ((NSError?) -> ()), success succeed : (T.Result) -> ()) {
+    public override func fetch(failure fail : ((NSError?) -> ()), success succeed : (T) -> ()) {
         self.cancelled = false
         dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), { [weak self] in
             if let strongSelf = self {
@@ -49,7 +49,7 @@ public class DiskFetcher<T : DataConvertible> : Fetcher<T> {
     
     // MARK: Private
     
-    private func privateFetch(failure fail : ((NSError?) -> ()), success succeed : (T.Result) -> ()) {
+    private func privateFetch(failure fail : ((NSError?) -> ()), success succeed : (T) -> ()) {
         if self.cancelled {
             return
         }
@@ -67,7 +67,7 @@ public class DiskFetcher<T : DataConvertible> : Fetcher<T> {
             return
         }
         
-        let value : T.Result? = T.convertFromData(data!)
+        let value = T(data:(data as! T.DataLiteralType))
         
         if value == nil {
             let localizedFormat = NSLocalizedString("Failed to convert value from data at path %@", comment: "Error description")

--- a/Haneke/Fetcher.swift
+++ b/Haneke/Fetcher.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 // See: http://stackoverflow.com/questions/25915306/generic-closure-in-protocol
-public class Fetcher<T : DataConvertible> {
+public class Fetcher<T : DataLiteralConvertable> {
 
     public let key : String
     
@@ -17,21 +17,21 @@ public class Fetcher<T : DataConvertible> {
         self.key = key
     }
     
-    func fetch(failure fail : ((NSError?) -> ()), success succeed : (T.Result) -> ()) {}
+    func fetch(failure fail : ((NSError?) -> ()), success succeed : (T) -> ()) {}
     
     func cancelFetch() {}
 }
 
-class SimpleFetcher<T : DataConvertible> : Fetcher<T> {
+class SimpleFetcher<T : DataLiteralConvertable> : Fetcher<T> {
     
-    let getValue : () -> T.Result
+    let getValue : () -> T
     
-    init(key : String, @autoclosure(escaping) value getValue : () -> T.Result) {
+    init(key : String, @autoclosure(escaping) value getValue : () -> T) {
         self.getValue = getValue
         super.init(key: key)
     }
     
-    override func fetch(failure fail : ((NSError?) -> ()), success succeed : (T.Result) -> ()) {
+    override func fetch(failure fail : ((NSError?) -> ()), success succeed : (T) -> ()) {
         let value = getValue()
         succeed(value)
     }

--- a/Haneke/NetworkFetcher.swift
+++ b/Haneke/NetworkFetcher.swift
@@ -23,7 +23,7 @@ extension HanekeGlobals {
     
 }
 
-public class NetworkFetcher<T : DataConvertible> : Fetcher<T> {
+public class NetworkFetcher<T : DataLiteralConvertable> : Fetcher<T> {
     
     let URL : NSURL
     
@@ -42,7 +42,7 @@ public class NetworkFetcher<T : DataConvertible> : Fetcher<T> {
     
     // MARK: Fetcher
     
-    public override func fetch(failure fail : ((NSError?) -> ()), success succeed : (T.Result) -> ()) {
+    public override func fetch(failure fail : ((NSError?) -> ()), success succeed : (T) -> ()) {
         self.cancelled = false
         self.task = self.session.dataTaskWithURL(self.URL) {[weak self] (data : NSData!, response : NSURLResponse!, error : NSError!) -> Void in
             if let strongSelf = self {
@@ -59,7 +59,7 @@ public class NetworkFetcher<T : DataConvertible> : Fetcher<T> {
     
     // MARK: Private
     
-    private func onReceiveData(data : NSData!, response : NSURLResponse!, error : NSError!, failure fail : ((NSError?) -> ()), success succeed : (T.Result) -> ()) {
+    private func onReceiveData(data : NSData!, response : NSURLResponse!, error : NSError!, failure fail : ((NSError?) -> ()), success succeed : (T) -> ()) {
 
         if cancelled { return }
         
@@ -92,8 +92,8 @@ public class NetworkFetcher<T : DataConvertible> : Fetcher<T> {
             self.failWithCode(.MissingData, localizedDescription: description, failure: fail)
             return
         }
-        
-        let value : T.Result? = T.convertFromData(data)
+        let d = data as! T.DataLiteralType
+        let value : T? = T(data: d)
         if value == nil {
             let localizedFormat = NSLocalizedString("Failed to convert value from data at URL %@", comment: "Error description")
             let description = String(format:localizedFormat, URL.absoluteString!)

--- a/HanekeTests/CacheTests.swift
+++ b/HanekeTests/CacheTests.swift
@@ -575,7 +575,7 @@ class ImageCacheTests: XCTestCase {
     
 }
 
-class FailFetcher<T : DataConvertible> : Fetcher<T> {
+class FailFetcher<T : DataLiteralConvertable> : Fetcher<T> {
     
     var error : NSError!
     
@@ -583,13 +583,13 @@ class FailFetcher<T : DataConvertible> : Fetcher<T> {
         super.init(key: key)
     }
     
-    override func fetch(failure fail : ((NSError?) -> ()), success succeed : (T.Result) -> ()) {
+    override func fetch(failure fail : ((NSError?) -> ()), success succeed : (T) -> ()) {
         fail(error)
     }
     
 }
 
-class CacheMock<T : DataConvertible where T.Result == T, T : DataRepresentable> : Cache<T> {
+class CacheMock<T : DataLiteralConvertable> : Cache<T> {
     
     var expectation : XCTestExpectation?
     

--- a/HanekeTests/DataTests.swift
+++ b/HanekeTests/DataTests.swift
@@ -15,7 +15,7 @@ class ImageDataTests: XCTestCase {
         let image = UIImage.imageGradientFromColor()
         let data = image.hnk_data()
 
-        let result = UIImage.convertFromData(data)
+        let result = UIImage(data: data)
 
         XCTAssertTrue(image.isEqualPixelByPixel(image))
     }
@@ -24,7 +24,7 @@ class ImageDataTests: XCTestCase {
         let image = UIImage.imageGradientFromColor()
         let data = image.hnk_data()
         
-        let result = image.asData()
+        let result = image.toData()!
         
         XCTAssertEqual(result, data)
     }
@@ -37,7 +37,7 @@ class StringDataTests: XCTestCase {
         let string = self.name
         let data = string.dataUsingEncoding(NSUTF8StringEncoding)!
         
-        let result = String.convertFromData(data)
+        let result = String(data: data)
         
         XCTAssertEqual(result!, string)
     }
@@ -46,7 +46,7 @@ class StringDataTests: XCTestCase {
         let string = self.name
         let data = string.dataUsingEncoding(NSUTF8StringEncoding)!
         
-        let result = string.asData()
+        let result = string.toData()!
         
         XCTAssertEqual(result, data)
     }
@@ -58,15 +58,15 @@ class DataDataTests: XCTestCase {
     func testConvertFromData() {
         let data = NSData.dataWithLength(32)
         
-        let result = NSData.convertFromData(data)
+        let result = NSData(data: data)
         
-        XCTAssertEqual(result!, data)
+        XCTAssertEqual(result, data)
     }
     
     func testAsData() {
         let data = NSData.dataWithLength(32)
         
-        let result = data.asData()
+        let result = data.toData()!
         
         XCTAssertEqual(result, data)
     }
@@ -79,7 +79,7 @@ class JSONDataTests: XCTestCase {
         let json = [self.name]
         let data = NSJSONSerialization.dataWithJSONObject(json, options: NSJSONWritingOptions.allZeros, error: nil)!
         
-        let result = JSON.convertFromData(data)!
+        let result = JSON(data:data)!
         
         switch result {
         case .Dictionary(_):
@@ -94,7 +94,7 @@ class JSONDataTests: XCTestCase {
         let json = ["test": self.name]
         let data = NSJSONSerialization.dataWithJSONObject(json, options: NSJSONWritingOptions.allZeros, error: nil)!
         
-        let result = JSON.convertFromData(data)!
+        let result = JSON(data:data)!
         
         switch result {
         case .Dictionary(let object):
@@ -107,7 +107,7 @@ class JSONDataTests: XCTestCase {
     func testConvertFromData_WithInvalidData() {
         let data = NSData.dataWithLength(100)
 
-        let result = JSON.convertFromData(data)
+        let result = JSON(data:data)
         
         XCTAssertTrue(result == nil)
     }
@@ -116,7 +116,7 @@ class JSONDataTests: XCTestCase {
         let object = [self.name]
         let json = JSON.Array(object)
         
-        let result = json.asData()
+        let result = json.toData()!
         
         let data = NSJSONSerialization.dataWithJSONObject(object, options: NSJSONWritingOptions.allZeros, error: nil)!
         XCTAssertEqual(result, data)
@@ -126,7 +126,7 @@ class JSONDataTests: XCTestCase {
         let object = ["test": self.name]
         let json = JSON.Dictionary(object)
         
-        let result = json.asData()
+        let result = json.toData()!
         
         let data = NSJSONSerialization.dataWithJSONObject(object, options: NSJSONWritingOptions.allZeros, error: nil)!
         XCTAssertEqual(result, data)

--- a/HanekeTests/UIImageView+HanekeTests.swift
+++ b/HanekeTests/UIImageView+HanekeTests.swift
@@ -549,13 +549,13 @@ class UIImageView_HanekeTests: DiskTestCase {
 
 }
 
-class MockFetcher<T : DataConvertible> : Fetcher<T> {
+class MockFetcher<T : DataLiteralConvertable> : Fetcher<T> {
     
     override init(key: String) {
         super.init(key: key)
     }
     
-    override func fetch(failure fail : ((NSError?) -> ()), success succeed : (T.Result) -> ()) {
+    override func fetch(failure fail : ((NSError?) -> ()), success succeed : (T) -> ()) {
         let error = errorWithCode(0, description: "test")
         fail(error)
     }


### PR DESCRIPTION
Got rid of the  DataConvertible, DataRepresentable protocols and replaced them with a simple DataLiteralConvertable class

no more ugly generic requirements of "<T : DataConvertible where T.Result == T, T : DataRepresentable>" and now they just say  <T : DataLiteralConvertable>

just requires a simple init() method.  

I couldn't use asData() due to some weird 'conflicts with Objective-C' error I got on one of the types.  So I renamed it to toData().
