### PR TITLE
Add Cache#getLevel

### DIFF
--- a/Haneke/Cache.swift
+++ b/Haneke/Cache.swift
@@ -33,6 +33,12 @@ extension HanekeGlobals {
     
 }
 
+public enum CacheLevel {
+    case Disk
+    case Memory
+    case None
+}
+
 public class Cache<T : DataConvertible where T.Result == T, T : DataRepresentable> {
     
     let name : String
@@ -120,6 +126,17 @@ public class Cache<T : DataConvertible where T.Result == T, T : DataRepresentabl
             fetch.succeed(value)
         }
         return fetch
+    }
+
+    public func getLevel(#key : String, formatName : String = HanekeGlobals.Cache.OriginalFormatName ) -> CacheLevel {
+      if let (_, memoryCache, diskCache) = self.formats[formatName] {
+        if (memoryCache.objectForKey(key) != nil) {
+          return CacheLevel.Memory
+        } else if (diskCache.containsKey(key)) {
+          return CacheLevel.Disk
+        }
+      }
+      return CacheLevel.None;
     }
 
     public func remove(#key : String, formatName : String = HanekeGlobals.Cache.OriginalFormatName) {

--- a/Haneke/DiskCache.swift
+++ b/Haneke/DiskCache.swift
@@ -72,6 +72,16 @@ public class DiskCache {
         })
     }
 
+    public func containsKey(key : String) -> Bool {
+        var result = false
+        dispatch_sync(cacheQueue) {
+            let path = self.pathForKey(key)
+            let fileManager = NSFileManager.defaultManager()
+            result = fileManager.fileExistsAtPath(path)
+        }
+        return result
+    }
+
     public func removeData(key : String) {
         dispatch_async(cacheQueue, {
             let path = self.pathForKey(key)

--- a/HanekeTests/DiskCacheTests.swift
+++ b/HanekeTests/DiskCacheTests.swift
@@ -147,7 +147,35 @@ class DiskCacheTests: XCTestCase {
             XCTAssertEqual(self.sut.size, UInt64(data.length))
         }
     }
-    
+
+    func testContainsKey() {
+        let data = UIImagePNGRepresentation(UIImage.imageWithColor(UIColor.redColor()))
+        let key = "key1"
+        let notFoundKey = "key2"
+
+        sut.setData(data, key: key)
+        XCTAssertTrue(self.sut.containsKey(key))
+        XCTAssertFalse(self.sut.containsKey(notFoundKey))
+    }
+
+    func testContainsKeyAfterRemovingFile() {
+        let data = UIImagePNGRepresentation(UIImage.imageWithColor(UIColor.redColor()))
+        let key = self.name
+        let path = sut.pathForKey(key)
+
+        sut.setData(data, key: key)
+        XCTAssertTrue(self.sut.containsKey(key))
+
+        dispatch_sync(sut.cacheQueue) {
+            let fileManager = NSFileManager.defaultManager()
+            var error : NSError?
+            fileManager.removeItemAtPath(path, error: &error)
+            XCTAssertNil(error)
+        }
+
+        XCTAssertFalse(self.sut.containsKey(key))
+    }
+
     func testSetData_WithKeyIncludingSpecialCharacters() {
         let sut = self.sut!
         let data = UIImagePNGRepresentation(UIImage.imageWithColor(UIColor.redColor()))


### PR DESCRIPTION
Using the above method we can check if the key is already in the cache and at which level it is cached, which may come handy when implementing some additional logic (usually in the wrapper).

