### PR TITLE
Fetcher access modifiers

### DIFF
--- a/Haneke/Fetcher.swift
+++ b/Haneke/Fetcher.swift
@@ -13,13 +13,13 @@ public class Fetcher<T : DataConvertible> {
 
     public let key: String
     
-    init(key: String) {
+    public init(key: String) {
         self.key = key
     }
     
-    func fetch(failure fail: ((NSError?) -> ()), success succeed: (T.Result) -> ()) {}
+    public func fetch(failure fail: ((NSError?) -> ()), success succeed: (T.Result) -> ()) {}
     
-    func cancelFetch() {}
+    public func cancelFetch() {}
 }
 
 class SimpleFetcher<T : DataConvertible> : Fetcher<T> {


### PR DESCRIPTION
Changed access modifiers to public so you can create your own fetcher in a separate module just importing Haneke and inheriting Fetcher<T> class