### PR TITLE
Enabled loading of http images in Demo for iOS 9.

### DIFF
--- a/HanekeDemo/Info.plist
+++ b/HanekeDemo/Info.plist
@@ -43,5 +43,10 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 </dict>
 </plist>


### PR DESCRIPTION
App Transport Security in iOS 9 defaults to disallowing loading resources using http. This exception allows the demo project to continue to function as it always has.

https://developer.apple.com/library/prerelease/ios/technotes/App-Transport-Security-Technote/