### PR TITLE
Extended initializer of NetworkFetcher in order to allow providing a …

### DIFF
--- a/Haneke/NetworkFetcher.swift
+++ b/Haneke/NetworkFetcher.swift
@@ -26,11 +26,11 @@ extension HanekeGlobals {
 public class NetworkFetcher<T : DataConvertible> : Fetcher<T> {
     
     let URL : NSURL
-    
-    public init(URL : NSURL) {
+  
+    public init(URL : NSURL, key : String? = nil) {
         self.URL = URL
 
-        let key =  URL.absoluteString
+        let key = key ?? URL.absoluteString
         super.init(key: key)
     }
     


### PR DESCRIPTION
…custom key, instead of the string representation of the URL.

We require this, because we have a setup where our thumbnail URLs are only valid for 48 hours and are regenerated every 24 hours. So our cache key is not the URL of the request. Do you think that this is a more generic requirement and therefor would consider including this within the next release of HanekeSwift?

Also, the change with the public initialiser init(key: String) of the Fetcher class has not yet made it into a release. The most recent release (0.10.0) still only has a non-public initialiser.
