### PR TITLE
fix deprecation of CFURLCreateStringByAddingPercentEscapes on tvOS

### DIFF
--- a/Haneke/String+Haneke.swift
+++ b/Haneke/String+Haneke.swift
@@ -11,12 +11,9 @@ import Foundation
 extension String {
 
     func escapedFilename() -> String {
-        let originalString = self as NSString as CFString
-        let charactersToLeaveUnescaped = " \\" as NSString as CFString // TODO: Add more characters that are valid in paths but not in URLs
-        let legalURLCharactersToBeEscaped = "/:" as NSString as CFString
-        let encoding = CFStringBuiltInEncodings.UTF8.rawValue
-        let escapedPath = CFURLCreateStringByAddingPercentEscapes(kCFAllocatorDefault, originalString, charactersToLeaveUnescaped, legalURLCharactersToBeEscaped, encoding)
-        return escapedPath as NSString as String
+        return [ "%":"%25", "\0":"%00", ":":"%3A", "/":"%2F" ].reduce(self) {
+            str, m in str.componentsSeparatedByString(m.0).joinWithSeparator(m.1)
+        }
     }
     
     func MD5String() -> String {

--- a/Haneke/String+Haneke.swift
+++ b/Haneke/String+Haneke.swift
@@ -9,10 +9,11 @@
 import Foundation
 
 extension String {
-
+    
     func escapedFilename() -> String {
-        return [ "%":"%25", "\0":"%00", ":":"%3A", "/":"%2F" ].reduce(self) {
-            str, m in str.componentsSeparatedByString(m.0).joinWithSeparator(m.1)
+        return [ "\0":"%00", ":":"%3A", "/":"%2F" ]
+            .reduce(self.componentsSeparatedByString("%").joinWithSeparator("%25")) {
+                str, m in str.componentsSeparatedByString(m.0).joinWithSeparator(m.1)
         }
     }
     


### PR DESCRIPTION
fix #260

non even sure `:` is disallowed