### PR TITLE
[Cache] removeAll: remove all files in cache path

### DIFF
--- a/Haneke/Cache.swift
+++ b/Haneke/Cache.swift
@@ -140,7 +140,9 @@ public class Cache<T: DataConvertible where T.Result == T, T : DataRepresentable
         }
         dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)) {
             let timeout = dispatch_time(DISPATCH_TIME_NOW, Int64(60 * NSEC_PER_SEC))
-            dispatch_group_wait(group, timeout);
+            if dispatch_group_wait(group, timeout) != 0 {
+                Log.error("removeAll timed out waiting for disk caches")
+            }
             let path = self.cachePath
             do {
                 try NSFileManager.defaultManager().removeItemAtPath(path)

--- a/Haneke/Cache.swift
+++ b/Haneke/Cache.swift
@@ -129,13 +129,32 @@ public class Cache<T: DataConvertible where T.Result == T, T : DataRepresentable
         }
     }
     
-    public func removeAll() {
+    public func removeAll(completion: (() -> ())? = nil) {
+        let group = dispatch_group_create();
         for (_, (_, memoryCache, diskCache)) in self.formats {
             memoryCache.removeAllObjects()
-            diskCache.removeAllData()
+            dispatch_group_enter(group)
+            diskCache.removeAllData {
+                dispatch_group_leave(group)
+            }
+        }
+        dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)) {
+            let timeout = dispatch_time(DISPATCH_TIME_NOW, Int64(60 * NSEC_PER_SEC))
+            dispatch_group_wait(group, timeout);
+            let path = self.cachePath
+            do {
+                try NSFileManager.defaultManager().removeItemAtPath(path)
+            } catch {
+                Log.error("Failed to remove path \(path)", error as NSError)
+            }
+            if let completion = completion {
+                dispatch_async(dispatch_get_main_queue()) {
+                    completion()
+                }
+            }
         }
     }
-    
+
     // MARK: Notifications
     
     func onMemoryWarning() {

--- a/Haneke/DiskCache.swift
+++ b/Haneke/DiskCache.swift
@@ -81,7 +81,7 @@ public class DiskCache {
         })
     }
     
-    public func removeAllData() {
+    public func removeAllData(completion: (() -> ())? = nil) {
         let fileManager = NSFileManager.defaultManager()
         let cachePath = self.path
         dispatch_async(cacheQueue, {
@@ -98,6 +98,11 @@ public class DiskCache {
                 self.calculateSize()
             } catch {
                 Log.error("Failed to list directory", error as NSError)
+            }
+            if let completion = completion {
+                dispatch_async(dispatch_get_main_queue()) {
+                    completion()
+                }
             }
         })
     }

--- a/HanekeTests/CacheTests.swift
+++ b/HanekeTests/CacheTests.swift
@@ -21,7 +21,13 @@ class CacheTests: XCTestCase {
     }
     
     override func tearDown() {
-        sut.removeAll()
+        var completed = false
+        sut.removeAll {
+            completed = true
+        }
+        self.wait(5) {
+            return completed
+        }
         super.tearDown()
     }
     

--- a/HanekeTests/CacheTests.swift
+++ b/HanekeTests/CacheTests.swift
@@ -483,6 +483,35 @@ class CacheTests: XCTestCase {
         }
         self.waitForExpectationsWithTimeout(1, handler: nil)
     }
+
+    func testRemoveAll_Completion() {
+        let key = self.name
+        sut.set(value: NSData.dataWithLength(18), key: key)
+        let expectation = self.expectationWithDescription("removeAll")
+        var completed = false
+        sut.removeAll {
+            completed = true
+            expectation.fulfill()
+        }
+
+        XCTAssertFalse(completed)
+        self.waitForExpectationsWithTimeout(1, handler: nil)
+    }
+
+    func testRemoveAll_WhenDataAlreadyPresentInCachePath() {
+        let path = (sut.cachePath as NSString).stringByAppendingPathComponent("test")
+        let data = NSData.dataWithLength(1)
+        data.writeToFile(path, atomically: true)
+        XCTAssertTrue(NSFileManager.defaultManager().fileExistsAtPath(path))
+
+        let expectation = self.expectationWithDescription("removeAll")
+        sut.removeAll {
+            expectation.fulfill()
+        }
+
+        self.waitForExpectationsWithTimeout(1, handler: nil)
+        XCTAssertFalse(NSFileManager.defaultManager().fileExistsAtPath(path))
+    }
     
     func testRemoveAll_AfterNone() {
         sut.removeAll()

--- a/HanekeTests/DiskCacheTests.swift
+++ b/HanekeTests/DiskCacheTests.swift
@@ -413,7 +413,23 @@ class DiskCacheTests: XCTestCase {
             XCTAssertEqual(Int(self.sut.size), 0)
         }
     }
-    
+
+    func testRemoveAllData_Completion_Filled() {
+        let key = self.name
+        let data = NSData.dataWithLength(12)
+        sut.setData(data, key: key)
+        let expectation = self.expectationWithDescription(self.name)
+
+        var completed = false
+        sut.removeAllData {
+            completed = true
+            expectation.fulfill()
+        }
+
+        XCTAssertFalse(completed)
+        self.waitForExpectationsWithTimeout(1, handler: nil)
+    }
+
     func testRemoveAllData_Empty() {
         let key = self.name
         let path = sut.pathForKey(key)

--- a/HanekeTests/DiskCacheTests.swift
+++ b/HanekeTests/DiskCacheTests.swift
@@ -26,7 +26,13 @@ class DiskCacheTests: XCTestCase {
     }
     
     override func tearDown() {
-        sut.removeAllData()
+        var completed = false
+        sut.removeAllData() {
+            completed = true
+        }
+        self.wait(5) {
+            return completed
+        }
         try! NSFileManager.defaultManager().removeItemAtPath(diskCachePath)
         super.tearDown()
     }


### PR DESCRIPTION
Remove all files in cache path no matter if the format was registered or not. Fixes #125.