### PR TITLE
remove query part of URL in getting pathExtension at MD5Filename

### DIFF
--- a/Haneke/String+Haneke.swift
+++ b/Haneke/String+Haneke.swift
@@ -35,7 +35,7 @@ extension String {
     
     func MD5Filename() -> String {
         let MD5String = self.MD5String()
-        let pathExtension = (self as NSString).pathExtension
+        let pathExtension = NSURL(string: self)?.pathExtension ?? (self as NSString).pathExtension
         if pathExtension.characters.count > 0 {
             return (MD5String as NSString).stringByAppendingPathExtension(pathExtension) ?? MD5String
         } else {


### PR DESCRIPTION
fixes #199 

NSString#pathExtension contains query part for URLString. (e.g. ext = `"jpg?bar"` for `"foo.jpg?bar"`.)
NSURL#pathExtension handles this kind of URLString.