### PR TITLE
Sets minimum deployment target to 9.0

### DIFF
--- a/Haneke.xcodeproj/project.pbxproj
+++ b/Haneke.xcodeproj/project.pbxproj
@@ -720,6 +720,7 @@
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
 			};
 			name = Debug;
 		};
@@ -740,6 +741,7 @@
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
No deployment target is set for the tvOS target. This causes compile time errors.