### PR TITLE
Respect main screen scale on convertFromData for UIImage

### DIFF
--- a/Haneke/Data.swift
+++ b/Haneke/Data.swift
@@ -29,7 +29,7 @@ extension UIImage : DataConvertible, DataRepresentable {
     // HACK: UIImage data initializer is no longer thread safe. See: https://github.com/AFNetworking/AFNetworking/issues/2572#issuecomment-115854482
     static func safeImageWithData(data:NSData) -> Result? {
         imageSync.lock()
-        let image = UIImage(data:data)
+        let image = UIImage(data:data, scale: scale)
         imageSync.unlock()
         return image
     }
@@ -42,6 +42,8 @@ extension UIImage : DataConvertible, DataRepresentable {
     public func asData() -> NSData! {
         return self.hnk_data()
     }
+    
+    private static let scale = UIScreen.mainScreen().scale
     
 }
 


### PR DESCRIPTION
Without `scale:` parameter, the image size will be matched to the pixel-based dimensions, which will cause size issue for auto-resizing-UIImageView such as `imageView` in `UITableViewCell`.