### PR TITLE
Custom disk cache and memory cache

### DIFF
--- a/Haneke/Cache.swift
+++ b/Haneke/Cache.swift
@@ -33,14 +33,14 @@ extension HanekeGlobals {
     
 }
 
-public class Cache<T: DataConvertible where T.Result == T, T : DataRepresentable>:AltCache<T, DiskCache, NSCache>{
+public class Cache<T: DataConvertible where T.Result == T, T : DataRepresentable>:HanekeCache<T, DiskCache, NSCache>{
 
     public override init(name: String) {
         super.init(name: name)
     }
 }
 
-public class AltCache<T: DataConvertible, DiskCacheT, MemoryCacheT where T.Result == T, T : DataRepresentable, DiskCacheT: DiskCache, MemoryCacheT: NSCache> {
+public class HanekeCache<T: DataConvertible, DiskCacheT, MemoryCacheT where T.Result == T, T : DataRepresentable, DiskCacheT: DiskCache, MemoryCacheT: NSCache> {
     
     let name: String
     

--- a/Haneke/DiskCache.swift
+++ b/Haneke/DiskCache.swift
@@ -36,7 +36,7 @@ public class DiskCache {
         return cacheQueue
     }()
     
-    public init(path: String, capacity: UInt64 = UINT64_MAX) {
+    required public init(path: String, capacity: UInt64 = UINT64_MAX) {
         self.path = path
         self.capacity = capacity
         dispatch_async(self.cacheQueue, {


### PR DESCRIPTION
I moved DiskCache and NSCache to the arguments of the generic class Cache, which is a subclass of HanekeCache.
The users who want to customize DiskCache or NSCache can now use HanekeCache with custom implementation (a subclass) of DiskCache and NSCache