### PR TITLE
Custom disk cache and memory cache 

### DIFF
--- a/Haneke/DiskCache.swift
+++ b/Haneke/DiskCache.swift
@@ -36,7 +36,7 @@ public class DiskCache {
         return cacheQueue
     }()
     
-    public init(path: String, capacity: UInt64 = UINT64_MAX) {
+    public required init(path: String, capacity: UInt64 = UINT64_MAX) {
         self.path = path
         self.capacity = capacity
         dispatch_async(self.cacheQueue, {


### PR DESCRIPTION
I have moved DiskCache and NSCache to the arguments of the generic class Cache, which is a subclass of HanekeCache.
The users who want to customize DiskCache or NSCache can use HanekeCache with custom implementation (a subclass) of DiskCache and NSCache