### PR TITLE
Migrate to Swift 2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 language: objective-c
 osx_image: xcode7.3
-xcode_workspace: Haneke.xcworkspace
-xcode_scheme: Haneke-iOS
-xcode_sdk: iphonesimulator9.3
 before_install:
 - brew update
 - brew install carthage || brew outdated carthage || brew upgrade carthage
@@ -11,3 +8,5 @@ install:
 branches:
   only:
     - master
+script:
+  - set -o pipefail && xcodebuild -workspace Haneke.xcworkspace -scheme Haneke-iOS -sdk iphonesimulator9.3 build test | xcpretty --color

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: objective-c
-osx_image: xcode7.2
+osx_image: xcode7.3
 xcode_workspace: Haneke.xcworkspace
 xcode_scheme: Haneke-iOS
-xcode_sdk: iphonesimulator9.2
+xcode_sdk: iphonesimulator9.3
 before_install:
 - brew update
 - brew install carthage || brew outdated carthage || brew upgrade carthage

--- a/Haneke/CryptoSwiftMD5.swift
+++ b/Haneke/CryptoSwiftMD5.swift
@@ -78,8 +78,8 @@ class HashBase {
         var msgLength = tmpMessage.length
         var counter = 0
         while msgLength % len != (len - 8) {
-            counter++
-            msgLength++
+            counter += 1
+            msgLength += 1
         }
         let bufZeros = UnsafeMutablePointer<UInt8>(calloc(counter, sizeof(UInt8)))
         tmpMessage.appendBytes(bufZeros, length: counter)
@@ -134,7 +134,13 @@ class MD5 : HashBase {
         // Process the message in successive 512-bit chunks:
         let chunkSizeBytes = 512 / 8 // 64
         var leftMessageBytes = tmpMessage.length
-        for (var i = 0; i < tmpMessage.length; i = i + chunkSizeBytes, leftMessageBytes -= chunkSizeBytes) {
+        var i = 0
+        while i < tmpMessage.length {
+            defer {
+                i = i + chunkSizeBytes
+                leftMessageBytes -= chunkSizeBytes
+            }
+
             let chunk = tmpMessage.subdataWithRange(NSRange(location: i, length: min(chunkSizeBytes,leftMessageBytes)))
             
             // break chunk into sixteen 32-bit words M[j], 0 ≤ j ≤ 15

--- a/Haneke/Data.swift
+++ b/Haneke/Data.swift
@@ -10,7 +10,7 @@ import UIKit
 
 // See: http://stackoverflow.com/questions/25922152/not-identical-to-self
 public protocol DataConvertible {
-    typealias Result
+    associatedtype Result
     
     static func convertFromData(data:NSData) -> Result?
 }

--- a/Haneke/UIButton+Haneke.swift
+++ b/Haneke/UIButton+Haneke.swift
@@ -12,7 +12,7 @@ public extension UIButton {
     
     public var hnk_imageFormat : Format<UIImage> {
         let bounds = self.bounds
-        assert(bounds.size.width > 0 && bounds.size.height > 0, "[\(Mirror(reflecting: self).description) \(__FUNCTION__)]: UIButton size is zero. Set its frame, call sizeToFit or force layout first. You can also set a custom format with a defined size if you don't want to force layout.")
+        assert(bounds.size.width > 0 && bounds.size.height > 0, "[\(Mirror(reflecting: self).description) \(#function)]: UIButton size is zero. Set its frame, call sizeToFit or force layout first. You can also set a custom format with a defined size if you don't want to force layout.")
             let contentRect = self.contentRectForBounds(bounds)
             let imageInsets = self.imageEdgeInsets
             let scaleMode = self.contentHorizontalAlignment != UIControlContentHorizontalAlignment.Fill || self.contentVerticalAlignment != UIControlContentVerticalAlignment.Fill ? ImageResizer.ScaleMode.AspectFit : ImageResizer.ScaleMode.Fill
@@ -126,7 +126,7 @@ public extension UIButton {
         
     public var hnk_backgroundImageFormat : Format<UIImage> {
         let bounds = self.bounds
-        assert(bounds.size.width > 0 && bounds.size.height > 0, "[\(Mirror(reflecting: self).description) \(__FUNCTION__)]: UIButton size is zero. Set its frame, call sizeToFit or force layout first. You can also set a custom format with a defined size if you don't want to force layout.")
+        assert(bounds.size.width > 0 && bounds.size.height > 0, "[\(Mirror(reflecting: self).description) \(#function)]: UIButton size is zero. Set its frame, call sizeToFit or force layout first. You can also set a custom format with a defined size if you don't want to force layout.")
             let imageSize = self.backgroundRectForBounds(bounds).size
             
             return HanekeGlobals.UIKit.formatWithSize(imageSize, scaleMode: .Fill)

--- a/Haneke/UIImageView+Haneke.swift
+++ b/Haneke/UIImageView+Haneke.swift
@@ -12,7 +12,7 @@ public extension UIImageView {
     
     public var hnk_format : Format<UIImage> {
         let viewSize = self.bounds.size
-            assert(viewSize.width > 0 && viewSize.height > 0, "[\(Mirror(reflecting: self).description) \(__FUNCTION__)]: UImageView size is zero. Set its frame, call sizeToFit or force layout first.")
+            assert(viewSize.width > 0 && viewSize.height > 0, "[\(Mirror(reflecting: self).description) \(#function)]: UImageView size is zero. Set its frame, call sizeToFit or force layout first.")
             let scaleMode = self.hnk_scaleMode
             return HanekeGlobals.UIKit.formatWithSize(viewSize, scaleMode: scaleMode)
     }

--- a/HanekeTests/CacheTests.swift
+++ b/HanekeTests/CacheTests.swift
@@ -17,7 +17,7 @@ class CacheTests: XCTestCase {
     
     override func setUp() {
         super.setUp()
-        sut = Cache<NSData>(name: self.name)
+        sut = Cache<NSData>(name: self.name!)
     }
     
     override func tearDown() {
@@ -40,7 +40,7 @@ class CacheTests: XCTestCase {
     }
     
     func testDeinit() {
-        weak var _ = Cache<UIImage>(name: self.name)
+        weak var _ = Cache<UIImage>(name: self.name!)
     }
     
     // MARK: cachePath
@@ -53,7 +53,7 @@ class CacheTests: XCTestCase {
     // MARK: formatPath
     
     func testFormatPath() {
-        let formatName = self.name
+        let formatName = self.name!
         let expectedFormatPath = (sut.cachePath as NSString).stringByAppendingPathComponent(formatName)
         
         let formatPath = sut.formatPath(formatName: formatName)
@@ -73,7 +73,7 @@ class CacheTests: XCTestCase {
     // MARK: addFormat
     
     func testAddFormat() {
-        let format = Format<NSData>(name: self.name)
+        let format = Format<NSData>(name: self.name!)
         
         sut.addFormat(format)
     }
@@ -81,10 +81,10 @@ class CacheTests: XCTestCase {
     // MARK: set
     
     func testSet_WithIdentityFormat_ExpectSyncSuccess() {
-        let sut = Cache<NSData>(name: self.name)
+        let sut = Cache<NSData>(name: self.name!)
         let data = NSData.dataWithLength(5)
-        let key = self.name
-        let expectation = self.expectationWithDescription(self.name)
+        let key = self.name!
+        let expectation = self.expectationWithDescription(self.name!)
         
         sut.set(value: data, key: key, success: {
             XCTAssertTrue($0 === data)
@@ -97,10 +97,10 @@ class CacheTests: XCTestCase {
     func testSet_WithCustomFormat_ExpectAsyncSuccess () {
         let data = NSData.dataWithLength(6)
         let expectedData = NSData.dataWithLength(7)
-        let key = self.name
-        let format = Format<NSData>(name: self.name, transform: { _ in return expectedData })
+        let key = self.name!
+        let format = Format<NSData>(name: self.name!, transform: { _ in return expectedData })
         sut.addFormat(format)
-        let expectation = self.expectationWithDescription(self.name)
+        let expectation = self.expectationWithDescription(self.name!)
         
         var finished = false
         sut.set(value: data, key: key, formatName : format.name, success: {
@@ -127,8 +127,8 @@ class CacheTests: XCTestCase {
     
     func testFetchOnSuccess_AfterSet_WithKey_ExpectSyncSuccess () {
         let data = NSData.dataWithLength(8)
-        let key = self.name
-        let expectation = self.expectationWithDescription(self.name)
+        let key = self.name!
+        let expectation = self.expectationWithDescription(key)
         sut.set(value: data, key: key)
 
         let fetch = sut.fetch(key: key).onSuccess {
@@ -142,8 +142,8 @@ class CacheTests: XCTestCase {
     }
     
     func testFetchOnFailure_WithKey_ExpectAsyncFailure () {
-        let key = self.name
-        let expectation = self.expectationWithDescription(self.name)
+        let key = self.name!
+        let expectation = self.expectationWithDescription(key)
         
         let fetch = sut.fetch(key: key).onFailure { error in
             XCTAssertEqual(error!.domain, HanekeGlobals.Domain)
@@ -159,8 +159,8 @@ class CacheTests: XCTestCase {
     
     func testFetch_AfterClearingMemoryCache_WithKey_ExpectAsyncSuccess () {
         let data = NSData.dataWithLength(9)
-        let key = self.name
-        let expectation = self.expectationWithDescription(self.name)
+        let key = self.name!
+        let expectation = self.expectationWithDescription(key)
         sut.set(value: data, key: key)
         self.clearMemoryCache()
         
@@ -181,8 +181,8 @@ class CacheTests: XCTestCase {
     }
     
     func testFetch_WithKeyAndExistingFormat_ExpectAsyncFailure () {
-        let key = self.name
-        let expectation = self.expectationWithDescription(self.name)
+        let key = self.name!
+        let expectation = self.expectationWithDescription(key)
         
         let fetch = sut.fetch(key: key, failure : { error in
             XCTAssertEqual(error!.domain, HanekeGlobals.Domain)
@@ -202,10 +202,10 @@ class CacheTests: XCTestCase {
     }
     
     func testFetch_WithKeyAndInexistingFormat_ExpectSyncFailure () {
-        let key = self.name
-        let expectation = self.expectationWithDescription(self.name)
+        let key = self.name!
+        let expectation = self.expectationWithDescription(key)
         
-        let fetch = sut.fetch(key: key, formatName: self.name, failure : { error in
+        let fetch = sut.fetch(key: key, formatName: key, failure : { error in
             XCTAssertEqual(error!.domain, HanekeGlobals.Domain)
             XCTAssertEqual(error!.code, HanekeGlobals.Cache.ErrorCode.FormatNotFound.rawValue)
             XCTAssertNotNil(error!.localizedDescription)
@@ -221,9 +221,9 @@ class CacheTests: XCTestCase {
     }
     
     func testFetch_AfterClearingMemoryCache_WithKeyAndFormatWithoutDiskCapacity_ExpectFailure() {
-        let key = self.name
+        let key = self.name!
         let data = NSData.dataWithLength(8)
-        let format = Format<NSData>(name: self.name, diskCapacity: 0)
+        let format = Format<NSData>(name: key, diskCapacity: 0)
         sut.addFormat(format)
         let expectation = self.expectationWithDescription("fetch image")
         sut.set(value: data, key: key, formatName: format.name)
@@ -240,11 +240,11 @@ class CacheTests: XCTestCase {
     }
     
     func testFetch_AfterClearingMemoryCache_WithKeyAndFormatWithDiskCapacity_ExpectSuccess() {
-        let key = self.name
+        let key = self.name!
         let data = NSData.dataWithLength(9)
-        let format = Format<NSData>(name: self.name)
+        let format = Format<NSData>(name: key)
         sut.addFormat(format)
-        let expectation = self.expectationWithDescription(self.name)
+        let expectation = self.expectationWithDescription(key)
         sut.set(value: data, key: key, formatName: format.name)
         self.clearMemoryCache()
         
@@ -260,8 +260,8 @@ class CacheTests: XCTestCase {
     
     func testFetchOnSuccess_WithSyncFetcher_ExpectAsyncSuccess () {
         let data = NSData.dataWithLength(10)
-        let fetcher = SimpleFetcher<NSData>(key: self.name, value: data)
-        let expectation = self.expectationWithDescription(self.name)
+        let fetcher = SimpleFetcher<NSData>(key: self.name!, value: data)
+        let expectation = self.expectationWithDescription(self.name!)
         
         let fetch = sut.fetch(fetcher: fetcher).onSuccess {
             XCTAssertTrue($0 === data)
@@ -277,9 +277,9 @@ class CacheTests: XCTestCase {
     
     func testFetchOnFailure_WithSyncFailingFetcher_ExpectAsyncFailure() {
         
-        let fetcher = FailFetcher<NSData>(key: self.name)
+        let fetcher = FailFetcher<NSData>(key: self.name!)
         fetcher.error = NSError(domain: "test", code: 376, userInfo: nil)
-        let expectation = self.expectationWithDescription(self.name)
+        let expectation = self.expectationWithDescription(self.name!)
         
         let fetch = sut.fetch(fetcher: fetcher).onFailure { error in
             XCTAssertEqual(error!, fetcher.error)
@@ -295,9 +295,9 @@ class CacheTests: XCTestCase {
     
     func testFetch_AfterSet_WithFetcher_ExpectSyncSuccess () {
         let data = NSData.dataWithLength(10)
-        let key = self.name
+        let key = self.name!
         let fetcher = SimpleFetcher<NSData>(key: key, value: data)
-        let expectation = self.expectationWithDescription(self.name)
+        let expectation = self.expectationWithDescription(key)
         sut.set(value: data, key: key)
         
         let fetch = sut.fetch(fetcher: fetcher, success: {
@@ -312,9 +312,9 @@ class CacheTests: XCTestCase {
     
     func testFetch_AfterSetAndClearingMemoryCache_WithFetcher_ExpectAsyncSuccess () {
         let data = NSData.dataWithLength(10)
-        let key = self.name
+        let key = self.name!
         let fetcher = SimpleFetcher<NSData>(key: key, value: data)
-        let expectation = self.expectationWithDescription(self.name)
+        let expectation = self.expectationWithDescription(key)
         sut.set(value: data, key: key)
         self.clearMemoryCache()
         
@@ -332,10 +332,10 @@ class CacheTests: XCTestCase {
     }
     
     func testFetch_WithSyncFetcher_ExpectAsyncSuccess () {
-        let key = self.name
+        let key = self.name!
         let data = NSData.dataWithLength(11)
         let fetcher = SimpleFetcher<NSData>(key: key, value: data)
-        let expectation = self.expectationWithDescription(self.name)
+        let expectation = self.expectationWithDescription(key)
         
         let fetch = sut.fetch(fetcher: fetcher, failure : { _ in
             XCTFail("expected success")
@@ -353,15 +353,15 @@ class CacheTests: XCTestCase {
     }
     
     func testFetch_WithFetcherAndCustomFormat_ExpectAsyncSuccess () {
-        let key = self.name
+        let key = self.name!
         let data = NSData.dataWithLength(12)
         let formattedData = NSData.dataWithLength(13)
         let fetcher = SimpleFetcher<NSData>(key: key, value: data)
-        let format = Format<NSData>(name: self.name, transform: { _ in
+        let format = Format<NSData>(name: key, transform: { _ in
             return formattedData
         })
         sut.addFormat(format)
-        let expectation = self.expectationWithDescription(self.name)
+        let expectation = self.expectationWithDescription(key)
         
         let fetch = sut.fetch(fetcher: fetcher, formatName : format.name, failure : { _ in
             XCTFail("expected sucesss")
@@ -379,11 +379,11 @@ class CacheTests: XCTestCase {
     }
     
     func testFetch_WithFetcherAndInexistingFormat_ExpectSyncFailure () {
-        let expectation = self.expectationWithDescription(self.name)
+        let expectation = self.expectationWithDescription(self.name!)
         let data = NSData.dataWithLength(14)
-        let fetcher = SimpleFetcher<NSData>(key: self.name, value: data)
+        let fetcher = SimpleFetcher<NSData>(key: self.name!, value: data)
 
-        let fetch = sut.fetch(fetcher: fetcher, formatName: self.name, failure : { error in
+        let fetch = sut.fetch(fetcher: fetcher, formatName: self.name!, failure : { error in
             XCTAssertEqual(error!.domain, HanekeGlobals.Domain)
             XCTAssertEqual(error!.code, HanekeGlobals.Cache.ErrorCode.FormatNotFound.rawValue)
             XCTAssertNotNil(error!.localizedDescription)
@@ -401,7 +401,7 @@ class CacheTests: XCTestCase {
     // MARK: remove
     
     func testRemove_WithExistingKey() {
-        let key = self.name
+        let key = self.name!
         sut.set(value: NSData.dataWithLength(14), key: key)
         let expectation = self.expectationWithDescription("fetch")
 
@@ -417,8 +417,8 @@ class CacheTests: XCTestCase {
     }
     
     func testRemove_WithExistingKeyInFormat() {
-        let key = self.name
-        let format = Format<NSData>(name: self.name)
+        let key = self.name!
+        let format = Format<NSData>(name: self.name!)
         sut.addFormat(format)
         sut.set(value:  NSData.dataWithLength(15), key: key, formatName: format.name)
         let expectation = self.expectationWithDescription("fetch")
@@ -435,8 +435,8 @@ class CacheTests: XCTestCase {
     }
     
     func testRemove_WithExistingKeyInAnotherFormat() {
-        let key = self.name
-        let format = Format<NSData>(name: self.name)
+        let key = self.name!
+        let format = Format<NSData>(name: key)
         sut.addFormat(format)
         sut.set(value: NSData.dataWithLength(16), key: key)
         let expectation = self.expectationWithDescription("fetch")
@@ -453,11 +453,11 @@ class CacheTests: XCTestCase {
     }
     
     func testRemove_WithExistingKeyAndInexistingFormat() {
-        let key = self.name
+        let key = self.name!
         sut.set(value: NSData.dataWithLength(17), key: key)
         let expectation = self.expectationWithDescription("fetch")
         
-        sut.remove(key: key, formatName: self.name)
+        sut.remove(key: key, formatName: key)
         
         sut.fetch(key: key, failure : { _ in
             XCTFail("expected success")
@@ -469,13 +469,13 @@ class CacheTests: XCTestCase {
     }
     
     func testRemove_WithInexistingKey() {
-        sut.remove(key: self.name)
+        sut.remove(key: self.name!)
     }
     
     // MARK: removeAll
     
     func testRemoveAll_AfterOne() {
-        let key = self.name
+        let key = self.name!
         sut.set(value: NSData.dataWithLength(18), key: key)
         let expectation = self.expectationWithDescription("fetch")
         
@@ -491,7 +491,7 @@ class CacheTests: XCTestCase {
     }
 
     func testRemoveAll_Completion() {
-        let key = self.name
+        let key = self.name!
         sut.set(value: NSData.dataWithLength(18), key: key)
         let expectation = self.expectationWithDescription("removeAll")
         var completed = false
@@ -524,7 +524,7 @@ class CacheTests: XCTestCase {
     }
     
     func testOnMemoryWarning() {
-        let key = self.name
+        let key = self.name!
         let data = NSData.dataWithLength(18)
         sut.set(value: data, key: key)
         let expectation = self.expectationWithDescription("fetch")
@@ -544,7 +544,7 @@ class CacheTests: XCTestCase {
     func testUIApplicationDidReceiveMemoryWarningNotification() {
         let expectation = expectationWithDescription("onMemoryWarning")
         
-        let sut = CacheMock<UIImage>(name: self.name)
+        let sut = CacheMock<UIImage>(name: self.name!)
         sut.expectation = expectation // XCode crashes if we use the original expectation directly
         
         NSNotificationCenter.defaultCenter().postNotificationName(UIApplicationDidReceiveMemoryWarningNotification, object: nil)
@@ -565,7 +565,7 @@ class ImageCacheTests: XCTestCase {
     
     override func setUp() {
         super.setUp()
-        sut = Cache<UIImage>(name: self.name)
+        sut = Cache<UIImage>(name: self.name!)
     }
     
     override func tearDown() {
@@ -574,10 +574,10 @@ class ImageCacheTests: XCTestCase {
     }
     
     func testSet_ExpectAsyncDecompressedImage() {
-        sut = Cache<UIImage>(name: self.name)
+        let key = self.name!
+        sut = Cache<UIImage>(name: key)
         let image = UIImage.imageWithColor(UIColor.greenColor())
-        let key = self.name
-        let expectation = self.expectationWithDescription(self.name)
+        let expectation = self.expectationWithDescription(key)
         
         var finished = false
         sut.set(value: image, key: key, success: {
@@ -593,8 +593,8 @@ class ImageCacheTests: XCTestCase {
     
     func testFetchOnSuccess_AfterSet_WithKey_ExpectSyncDecompressedImage () {
         let image = UIImage.imageWithColor(UIColor.cyanColor())
-        let key = self.name
-        let expectation = self.expectationWithDescription(self.name)
+        let key = self.name!
+        let expectation = self.expectationWithDescription(key)
         sut.set(value: image, key: key, success: { decompressedImage in
             
             self.sut.fetch(key: key).onSuccess {

--- a/HanekeTests/DataTests.swift
+++ b/HanekeTests/DataTests.swift
@@ -35,7 +35,7 @@ class ImageDataTests: XCTestCase {
 class StringDataTests: XCTestCase {
     
     func testConvertFromData() {
-        let string = self.name
+        let string = self.name!
         let data = string.dataUsingEncoding(NSUTF8StringEncoding)!
         
         let result = String.convertFromData(data)
@@ -44,7 +44,7 @@ class StringDataTests: XCTestCase {
     }
     
     func testAsData() {
-        let string = self.name
+        let string = self.name!
         let data = string.dataUsingEncoding(NSUTF8StringEncoding)!
         
         let result = string.asData()
@@ -77,7 +77,7 @@ class DataDataTests: XCTestCase {
 class JSONDataTests: XCTestCase {
     
     func testConvertFromData_WithArrayData() {
-        let json = [self.name]
+        let json = [self.name!]
         let data = try! NSJSONSerialization.dataWithJSONObject(json, options: NSJSONWritingOptions())
         
         let result = JSON.convertFromData(data)!
@@ -92,7 +92,7 @@ class JSONDataTests: XCTestCase {
     }
     
     func testConvertFromData_WithDictionaryData() {
-        let json = ["test": self.name]
+        let json = ["test": self.name!]
         let data = try! NSJSONSerialization.dataWithJSONObject(json, options: NSJSONWritingOptions())
         
         let result = JSON.convertFromData(data)!
@@ -114,7 +114,7 @@ class JSONDataTests: XCTestCase {
     }
     
     func testAsData_Array() {
-        let object = [self.name]
+        let object = [self.name!]
         let json = JSON.Array(object)
         
         let result = json.asData()
@@ -124,7 +124,7 @@ class JSONDataTests: XCTestCase {
     }
     
     func testAsData_Dictionary() {
-        let object = ["test": self.name]
+        let object = ["test": self.name!]
         let json = JSON.Dictionary(object)
         
         let result = json.asData()
@@ -143,7 +143,7 @@ class JSONDataTests: XCTestCase {
     }
     
     func testArray_Array() {
-        let object = [self.name]
+        let object = [self.name!]
         let json = JSON.Array(object)
         
         let result = json.array
@@ -152,7 +152,7 @@ class JSONDataTests: XCTestCase {
     }
     
     func testArray_Dictionary() {
-        let object = ["test": self.name]
+        let object = ["test": self.name!]
         let json = JSON.Dictionary(object)
         
         let result = json.array
@@ -161,7 +161,7 @@ class JSONDataTests: XCTestCase {
     }
     
     func testDictionary_Array() {
-        let object = [self.name]
+        let object = [self.name!]
         let json = JSON.Array(object)
         
         let result = json.dictionary
@@ -170,7 +170,7 @@ class JSONDataTests: XCTestCase {
     }
     
     func testDictionary_Dictionary() {
-        let object = ["test": self.name]
+        let object = ["test": self.name!]
         let json = JSON.Dictionary(object)
         
         let result = json.dictionary

--- a/HanekeTests/DiskCacheTests.swift
+++ b/HanekeTests/DiskCacheTests.swift
@@ -15,7 +15,7 @@ class DiskCacheTests: XCTestCase {
     var sut : DiskCache!
     
     lazy var diskCachePath: String = {
-        let diskCachePath =  (DiskCache.basePath() as NSString).stringByAppendingPathComponent(self.name)
+        let diskCachePath =  (DiskCache.basePath() as NSString).stringByAppendingPathComponent(self.name!)
         try! NSFileManager.defaultManager().createDirectoryAtPath(diskCachePath, withIntermediateDirectories: true, attributes: nil)
         return diskCachePath
     }()
@@ -125,7 +125,7 @@ class DiskCacheTests: XCTestCase {
     }
     
     func testSetCapacity() {
-        sut.setData(NSData.dataWithLength(1), key: self.name)
+        sut.setData(NSData.dataWithLength(1), key: self.name!)
         
         sut.capacity = 0
         
@@ -136,7 +136,7 @@ class DiskCacheTests: XCTestCase {
     
     func testSetData() {
         let data = UIImagePNGRepresentation(UIImage.imageWithColor(UIColor.redColor()))!
-        let key = self.name
+        let key = self.name!
         let path = sut.pathForKey(key)
         
         sut.setData(data, key: key)
@@ -199,7 +199,7 @@ class DiskCacheTests: XCTestCase {
     func testSetDataReplace() {
         let originalData = NSData.dataWithLength(5)
         let data = NSData.dataWithLength(14)
-        let key = self.name
+        let key = self.name!
         let path = sut.pathForKey(key)
         sut.setData(originalData, key: key)
         
@@ -215,7 +215,7 @@ class DiskCacheTests: XCTestCase {
     }
     
     func testSetDataNil() {
-        let key = self.name
+        let key = self.name!
         let path = sut.pathForKey(key)
         
         sut.setData({ return nil }(), key: key)
@@ -229,7 +229,7 @@ class DiskCacheTests: XCTestCase {
     
     func testSetDataControlCapacity() {
         let sut = DiskCache(path: diskCachePath, capacity:0)
-        let key = self.name
+        let key = self.name!
         let path = sut.pathForKey(key)
         
         sut.setData(NSData.dataWithLength(1), key: key)
@@ -243,10 +243,10 @@ class DiskCacheTests: XCTestCase {
     
     func testFetchData() {
         let data = NSData.dataWithLength(14)
-        let key = self.name
+        let key = self.name!
         sut.setData(data, key : key)
         
-        let expectation = self.expectationWithDescription(self.name)
+        let expectation = self.expectationWithDescription(key)
         
         sut.fetchData(key: key, success: {
             expectation.fulfill()
@@ -258,8 +258,8 @@ class DiskCacheTests: XCTestCase {
     }
     
     func testFetchData_Inexisting() {
-        let key = self.name
-        let expectation = self.expectationWithDescription(self.name)
+        let key = self.name!
+        let expectation = self.expectationWithDescription(key)
         
         sut.fetchData(key: key, failure : { error in
             XCTAssertEqual(error!.code, NSFileReadNoSuchFileError)
@@ -274,7 +274,7 @@ class DiskCacheTests: XCTestCase {
     }
     
     func testFetchData_Inexisting_NilFailureBlock() {
-        let key = self.name
+        let key = self.name!
         
         sut.fetchData(key: key, success: { _ in
             XCTFail("Expected failure")
@@ -286,14 +286,14 @@ class DiskCacheTests: XCTestCase {
     func testFetchData_UpdateAccessDate() {
         let now = NSDate()
         let data = NSData.dataWithLength(19)
-        let key = self.name
+        let key = self.name!
         sut.setData(data, key : key)
         let path = sut.pathForKey(key)
         let fileManager = NSFileManager.defaultManager()
         dispatch_sync(sut.cacheQueue, {
             try! fileManager.setAttributes([NSFileModificationDate : NSDate.distantPast()], ofItemAtPath: path)
         })
-        let expectation = self.expectationWithDescription(self.name)
+        let expectation = self.expectationWithDescription(key)
         
         // Preconditions
         dispatch_sync(sut.cacheQueue) {
@@ -319,7 +319,7 @@ class DiskCacheTests: XCTestCase {
     func testUpdateAccessDateFileInDisk() {
         let now = NSDate()
         let data = NSData.dataWithLength(10)
-        let key = self.name
+        let key = self.name!
         sut.setData(data, key : key)
         let path = sut.pathForKey(key)
         let fileManager = NSFileManager.defaultManager()
@@ -347,7 +347,7 @@ class DiskCacheTests: XCTestCase {
     
     func testUpdateAccessDateFileNotInDisk() {
         let image = UIImage.imageWithColor(UIColor.redColor())
-        let key = self.name
+        let key = self.name!
         let path = sut.pathForKey(key)
         let fileManager = NSFileManager.defaultManager()
         
@@ -380,7 +380,7 @@ class DiskCacheTests: XCTestCase {
     }
     
     func testRemoveDataExisting() {
-        let key = self.name
+        let key = self.name!
         let data = UIImagePNGRepresentation(UIImage.imageWithColor(UIColor.redColor()))
         let path = sut.pathForKey(key)
         sut.setData(data, key: key)
@@ -395,18 +395,18 @@ class DiskCacheTests: XCTestCase {
     }
     
     func testRemoveDataInexisting() {
-        let key = self.name
+        let key = self.name!
         let path = sut.pathForKey(key)
         let fileManager = NSFileManager.defaultManager()
         
         // Preconditions
         XCTAssertFalse(fileManager.fileExistsAtPath(path))
         
-        sut.removeData(self.name)
+        sut.removeData(key)
     }
     
     func testRemoveAllData_Filled() {
-        let key = self.name
+        let key = self.name!
         let data = NSData.dataWithLength(12)
         let path = sut.pathForKey(key)
         sut.setData(data, key: key)
@@ -421,10 +421,10 @@ class DiskCacheTests: XCTestCase {
     }
 
     func testRemoveAllData_Completion_Filled() {
-        let key = self.name
+        let key = self.name!
         let data = NSData.dataWithLength(12)
         sut.setData(data, key: key)
-        let expectation = self.expectationWithDescription(self.name)
+        let expectation = self.expectationWithDescription(key)
 
         var completed = false
         sut.removeAllData {
@@ -437,7 +437,7 @@ class DiskCacheTests: XCTestCase {
     }
 
     func testRemoveAllData_Empty() {
-        let key = self.name
+        let key = self.name!
         let path = sut.pathForKey(key)
         let fileManager = NSFileManager.defaultManager()
         
@@ -448,7 +448,7 @@ class DiskCacheTests: XCTestCase {
     }
     
     func testRemoveAllData_ThenSetData() {
-        let key = self.name
+        let key = self.name!
         let path = sut.pathForKey(key)
         let data = NSData.dataWithLength(12)
         
@@ -490,7 +490,7 @@ class DiskCacheTests: XCTestCase {
         let data = NSData.dataWithLength(length)
         let path = (directory as NSString).stringByAppendingPathComponent("\(dataIndex)")
         data.writeToFile(path, atomically: true)
-        dataIndex++
+        dataIndex += 1
         return path
     }
 

--- a/HanekeTests/DiskFetcherTests.swift
+++ b/HanekeTests/DiskFetcherTests.swift
@@ -34,7 +34,7 @@ class DiskFetcherTests: DiskTestCase {
         let data = UIImagePNGRepresentation(image)!
         data.writeToFile(sut.path, atomically: true)
         
-        let expectation = self.expectationWithDescription(self.name)
+        let expectation = self.expectationWithDescription(self.name!)
         
         sut.fetch(failure: { _ in
             XCTFail("Expected to succeed")
@@ -49,7 +49,7 @@ class DiskFetcherTests: DiskTestCase {
     }
     
     func testFetchImage_Failure_NSFileReadNoSuchFileError() {
-        let expectation = self.expectationWithDescription(self.name)
+        let expectation = self.expectationWithDescription(self.name!)
         
         sut.fetch(failure: {
             XCTAssertEqual($0!.code, NSFileReadNoSuchFileError)
@@ -67,7 +67,7 @@ class DiskFetcherTests: DiskTestCase {
         let data = NSData()
         data.writeToFile(sut.path, atomically: true)
         
-        let expectation = self.expectationWithDescription(self.name)
+        let expectation = self.expectationWithDescription(self.name!)
         
         sut.fetch(failure: {
             XCTAssertEqual($0!.domain, HanekeGlobals.Domain)
@@ -106,8 +106,8 @@ class DiskFetcherTests: DiskTestCase {
     func testCacheFetch_Success() {
         let data = NSData.dataWithLength(1)
         let path = self.writeData(data)
-        let expectation = self.expectationWithDescription(self.name)
-        let cache = Cache<NSData>(name: self.name)
+        let expectation = self.expectationWithDescription(self.name!)
+        let cache = Cache<NSData>(name: self.name!)
         
         cache.fetch(path: path, failure: {_ in
             XCTFail("expected success")
@@ -123,9 +123,9 @@ class DiskFetcherTests: DiskTestCase {
     }
     
     func testCacheFetch_Failure() {
-        let path = (self.directoryPath as NSString).stringByAppendingPathComponent(self.name)
-        let expectation = self.expectationWithDescription(self.name)
-        let cache = Cache<NSData>(name: self.name)
+        let path = (self.directoryPath as NSString).stringByAppendingPathComponent(self.name!)
+        let expectation = self.expectationWithDescription(self.name!)
+        let cache = Cache<NSData>(name: self.name!)
         
         cache.fetch(path: path, failure: {_ in
             expectation.fulfill()
@@ -142,9 +142,9 @@ class DiskFetcherTests: DiskTestCase {
     func testCacheFetch_WithFormat() {
         let data = NSData.dataWithLength(1)
         let path = self.writeData(data)
-        let expectation = self.expectationWithDescription(self.name)
-        let cache = Cache<NSData>(name: self.name)
-        let format = Format<NSData>(name: self.name)
+        let expectation = self.expectationWithDescription(self.name!)
+        let cache = Cache<NSData>(name: self.name!)
+        let format = Format<NSData>(name: self.name!)
         cache.addFormat(format)
         
         cache.fetch(path: path, formatName: format.name, failure: {_ in

--- a/HanekeTests/DiskTestCase.swift
+++ b/HanekeTests/DiskTestCase.swift
@@ -12,7 +12,7 @@ class DiskTestCase : XCTestCase {
  
     lazy var directoryPath: String = {
         let documentsPath = NSSearchPathForDirectoriesInDomains(NSSearchPathDirectory.DocumentDirectory, NSSearchPathDomainMask.UserDomainMask, true)[0]
-        let directoryPath = (documentsPath as NSString).stringByAppendingPathComponent(self.name)
+        let directoryPath = (documentsPath as NSString).stringByAppendingPathComponent(self.name!)
         return directoryPath
     }()
     
@@ -41,7 +41,7 @@ class DiskTestCase : XCTestCase {
     
     func uniquePath() -> String {
         let path = (self.directoryPath as NSString).stringByAppendingPathComponent("\(dataIndex)")
-        dataIndex++
+        dataIndex += 1
         return path
     }
     

--- a/HanekeTests/FetchTests.swift
+++ b/HanekeTests/FetchTests.swift
@@ -20,7 +20,7 @@ class FetchTests : XCTestCase {
     }
 
     func testHasSucceded_True() {
-        sut.succeed(self.name)
+        sut.succeed(self.name!)
         
         XCTAssertTrue(sut.hasSucceeded)
     }
@@ -46,18 +46,18 @@ class FetchTests : XCTestCase {
     }
     
     func testHasSucceded_AfterSucceed_False() {
-        sut.succeed(self.name)
+        sut.succeed(self.name!)
         
         XCTAssertFalse(sut.hasFailed)
     }
     
     func testSucceed() {
-        sut.succeed(self.name)
+        sut.succeed(self.name!)
     }
 
     func testSucceed_AfterOnSuccess() {
-        let value = self.name
-        let expectation = self.expectationWithDescription(self.name)
+        let value = self.name!
+        let expectation = self.expectationWithDescription(value)
         sut.onSuccess {
             XCTAssertEqual($0, value)
             expectation.fulfill()
@@ -73,8 +73,8 @@ class FetchTests : XCTestCase {
     }
     
     func testFail_AfterOnFailure() {
-        let error = NSError(domain: self.name, code: 10, userInfo: nil)
-        let expectation = self.expectationWithDescription(self.name)
+        let error = NSError(domain: self.name!, code: 10, userInfo: nil)
+        let expectation = self.expectationWithDescription(self.name!)
         sut.onFailure {
             XCTAssertEqual($0!, error)
             expectation.fulfill()
@@ -92,9 +92,9 @@ class FetchTests : XCTestCase {
     }
     
     func testOnSuccess_AfterSucceed() {
-        let value = self.name
+        let value = self.name!
         sut.succeed(value)
-        let expectation = self.expectationWithDescription(self.name)
+        let expectation = self.expectationWithDescription(value)
         
         sut.onSuccess {
             XCTAssertEqual($0, value)
@@ -111,9 +111,9 @@ class FetchTests : XCTestCase {
     }
     
     func testOnFailure_AfterFail() {
-        let error = NSError(domain: self.name, code: 10, userInfo: nil)
+        let error = NSError(domain: self.name!, code: 10, userInfo: nil)
         sut.fail(error)
-        let expectation = self.expectationWithDescription(self.name)
+        let expectation = self.expectationWithDescription(self.name!)
         
         sut.onFailure {
             XCTAssertEqual($0!, error)

--- a/HanekeTests/FetcherTests.swift
+++ b/HanekeTests/FetcherTests.swift
@@ -13,7 +13,7 @@ import XCTest
 class FetcherTests: XCTestCase {
     
     func testSimpleFetcherInit() {
-        let key = self.name
+        let key = self.name!
         let image = UIImage.imageWithColor(UIColor.greenColor())
         
         let fetcher = SimpleFetcher<UIImage>(key: key, value: image)
@@ -23,10 +23,10 @@ class FetcherTests: XCTestCase {
     }
     
     func testSimpleFetcherFetch() {
-        let key = self.name
+        let key = self.name!
         let image = UIImage.imageWithColor(UIColor.greenColor())
         let fetcher = SimpleFetcher<UIImage>(key: key, value: image)
-        let expectation = self.expectationWithDescription(self.name)
+        let expectation = self.expectationWithDescription(key)
         
         fetcher.fetch(failure: { _ in
             XCTFail("expected success")
@@ -40,10 +40,10 @@ class FetcherTests: XCTestCase {
     
     func testCacheFetch() {
         let data = NSData.dataWithLength(1)
-        let expectation = self.expectationWithDescription(self.name)
-        let cache = Cache<NSData>(name: self.name)
+        let expectation = self.expectationWithDescription(self.name!)
+        let cache = Cache<NSData>(name: self.name!)
         
-        cache.fetch(key: self.name, value: data) {
+        cache.fetch(key: self.name!, value: data) {
             XCTAssertEqual($0, data)
             expectation.fulfill()
         }
@@ -55,12 +55,12 @@ class FetcherTests: XCTestCase {
     
     func testCacheFetch_WithFormat() {
         let data = NSData.dataWithLength(1)
-        let expectation = self.expectationWithDescription(self.name)
-        let cache = Cache<NSData>(name: self.name)
-        let format = Format<NSData>(name: self.name)
+        let expectation = self.expectationWithDescription(self.name!)
+        let cache = Cache<NSData>(name: self.name!)
+        let format = Format<NSData>(name: self.name!)
         cache.addFormat(format)
         
-        cache.fetch(key: self.name, value: data, formatName: format.name) {
+        cache.fetch(key: self.name!, value: data, formatName: format.name) {
             XCTAssertEqual($0, data)
             expectation.fulfill()
         }

--- a/HanekeTests/FormatTests.swift
+++ b/HanekeTests/FormatTests.swift
@@ -13,7 +13,7 @@ import XCTest
 class FormatTests: XCTestCase {
 
     func testDefaultInit() {
-        let name = self.name
+        let name = self.name!
         let sut = Format<UIImage>(name: name)
         
         XCTAssertEqual(sut.name, name)
@@ -22,13 +22,13 @@ class FormatTests: XCTestCase {
     }
     
     func testIsIdentity_WithoutTransform_ExpectTrue() {
-        let sut = Format<UIImage>(name: name)
+        let sut = Format<UIImage>(name: self.name!)
         
         XCTAssertTrue(sut.isIdentity)
     }
     
     func testIsIdentity_WithTransform_ExpectFalse() {
-        let sut = Format<UIImage>(name: name, transform: { return $0 })
+        let sut = Format<UIImage>(name: self.name!, transform: { return $0 })
         
         XCTAssertFalse(sut.isIdentity)
     }

--- a/HanekeTests/HanekeTests.swift
+++ b/HanekeTests/HanekeTests.swift
@@ -14,7 +14,7 @@ class HanekeTests: XCTestCase {
     func testErrorWithCode() {
         let code = 200
         let description = self.name
-        let error = errorWithCode(code, description:description)
+        let error = errorWithCode(code, description:description!)
         
         XCTAssertEqual(error.domain, HanekeGlobals.Domain)
         XCTAssertEqual(error.code, code)

--- a/HanekeTests/NSFileManager+HanekeTests.swift
+++ b/HanekeTests/NSFileManager+HanekeTests.swift
@@ -25,7 +25,7 @@ class NSFileManager_HanekeTests: DiskTestCase {
         var count = 0
         
         sut.enumerateContentsOfDirectoryAtPath(self.directoryPath, orderedByProperty: NSURLNameKey, ascending: true) { (_ : NSURL, index : Int, inout stop : Bool) -> Void in
-            count++
+            count += 1
             stop = true
         }
         

--- a/HanekeTests/NetworkFetcherTests.swift
+++ b/HanekeTests/NetworkFetcherTests.swift
@@ -42,7 +42,7 @@ class NetworkFetcherTests: XCTestCase {
             let data = UIImagePNGRepresentation(image)
             return OHHTTPStubsResponse(data: data!, statusCode: 200, headers:nil)
         })
-        let expectation = self.expectationWithDescription(self.name)
+        let expectation = self.expectationWithDescription(self.name!)
         
         sut.fetch(failure: { _ in
             XCTFail("expected success")
@@ -87,7 +87,7 @@ class NetworkFetcherTests: XCTestCase {
             let data = NSData()
             return OHHTTPStubsResponse(data: data, statusCode: 200, headers:nil)
         })
-        let expectation = self.expectationWithDescription(self.name)
+        let expectation = self.expectationWithDescription(self.name!)
         
         sut.fetch(failure: {
             XCTAssertEqual($0!.domain, HanekeGlobals.Domain)
@@ -109,7 +109,7 @@ class NetworkFetcherTests: XCTestCase {
             let data = NSData.dataWithLength(100)
             return OHHTTPStubsResponse(data: data, statusCode: 200, headers:["Content-Length":String(data.length * 2)])
         })
-        let expectation = self.expectationWithDescription(self.name)
+        let expectation = self.expectationWithDescription(self.name!)
         
         sut.fetch(failure: {
             XCTAssertEqual($0!.domain, HanekeGlobals.Domain)
@@ -161,7 +161,7 @@ class NetworkFetcherTests: XCTestCase {
                 let data = UIImagePNGRepresentation(image)
                 return OHHTTPStubsResponse(data: data!, statusCode: statusCode, headers:nil)
         })
-        let expectation = self.expectationWithDescription(self.name)
+        let expectation = self.expectationWithDescription(self.name!)
         sut.cancelFetch()
 
         sut.fetch(failure: { _ in
@@ -183,7 +183,7 @@ class NetworkFetcherTests: XCTestCase {
             let data = NSData.dataWithLength(100)
             return OHHTTPStubsResponse(data: data, statusCode: statusCode, headers:nil)
         })
-        let expectation = self.expectationWithDescription(self.name)
+        let expectation = self.expectationWithDescription(self.name!)
         
         sut.fetch(failure: {
             XCTAssertEqual($0!.domain, HanekeGlobals.Domain)
@@ -207,8 +207,8 @@ class NetworkFetcherTests: XCTestCase {
             }, withStubResponse: { _ in
                 return OHHTTPStubsResponse(data: data, statusCode: 200, headers:nil)
         })
-        let expectation = self.expectationWithDescription(self.name)
-        let cache = Cache<NSData>(name: self.name)
+        let expectation = self.expectationWithDescription(self.name!)
+        let cache = Cache<NSData>(name: self.name!)
 
         cache.fetch(URL: URL, failure: {_ in
             XCTFail("expected success")
@@ -230,8 +230,8 @@ class NetworkFetcherTests: XCTestCase {
             }, withStubResponse: { _ in
                 return OHHTTPStubsResponse(data: data, statusCode: 404, headers:nil)
         })
-        let expectation = self.expectationWithDescription(self.name)
-        let cache = Cache<NSData>(name: self.name)
+        let expectation = self.expectationWithDescription(self.name!)
+        let cache = Cache<NSData>(name: self.name!)
         
         cache.fetch(URL: URL, failure: {_ in
             expectation.fulfill()
@@ -252,9 +252,9 @@ class NetworkFetcherTests: XCTestCase {
             }, withStubResponse: { _ in
                 return OHHTTPStubsResponse(data: data, statusCode: 404, headers:nil)
         })
-        let expectation = self.expectationWithDescription(self.name)
-        let cache = Cache<NSData>(name: self.name)
-        let format = Format<NSData>(name: self.name)
+        let expectation = self.expectationWithDescription(self.name!)
+        let cache = Cache<NSData>(name: self.name!)
+        let format = Format<NSData>(name: self.name!)
         cache.addFormat(format)
 
         cache.fetch(URL: URL, formatName: format.name, failure: {_ in

--- a/HanekeTests/UIButton+HanekeTests.swift
+++ b/HanekeTests/UIButton+HanekeTests.swift
@@ -47,7 +47,7 @@ class UIButton_HanekeTests: DiskTestCase {
     
     func testSetImage_MemoryMiss_UIControlStateNormal() {
         let image = UIImage.imageWithColor(UIColor.greenColor())
-        let key = self.name
+        let key = self.name!
         
         sut.hnk_setImage(image, key: key)
         
@@ -57,7 +57,7 @@ class UIButton_HanekeTests: DiskTestCase {
     
     func testSetImage_MemoryHit_UIControlStateSelected() {
         let image = UIImage.imageWithColor(UIColor.greenColor())
-        let key = self.name
+        let key = self.name!
         let expectedImage = setImage(image, key: key, format: sut.hnk_imageFormat)
         
         sut.hnk_setImage(image, key: key, state: .Selected)
@@ -69,7 +69,7 @@ class UIButton_HanekeTests: DiskTestCase {
     func testSetImage_UsingPlaceholder_MemoryMiss_UIControlStateDisabled() {
         let placeholder = UIImage.imageWithColor(UIColor.yellowColor())
         let image = UIImage.imageWithColor(UIColor.greenColor())
-        let key = self.name
+        let key = self.name!
         
         sut.hnk_setImage(image, key: key, state: .Disabled, placeholder: placeholder)
         
@@ -80,7 +80,7 @@ class UIButton_HanekeTests: DiskTestCase {
     func testSetImage_UsingPlaceholder_MemoryHit_UIControlStateNormal() {
         let placeholder = UIImage.imageWithColor(UIColor.yellowColor())
         let image = UIImage.imageWithColor(UIColor.greenColor())
-        let key = self.name
+        let key = self.name!
         let expectedImage = setImage(image, key: key, format: sut.hnk_imageFormat)
         
         sut.hnk_setImage(image, key: key, placeholder: placeholder)
@@ -92,9 +92,9 @@ class UIButton_HanekeTests: DiskTestCase {
     func testSetImage_UsingFormat_UIControlStateHighlighted() {
         let image = UIImage.imageWithColor(UIColor.redColor())
         let expectedImage = UIImage.imageWithColor(UIColor.greenColor())
-        let format = Format<UIImage>(name: self.name, diskCapacity: 0) { _ in return expectedImage }
-        let key = self.name
-        let expectation = self.expectationWithDescription(self.name)
+        let format = Format<UIImage>(name: self.name!, diskCapacity: 0) { _ in return expectedImage }
+        let key = self.name!
+        let expectation = self.expectationWithDescription(self.name!)
         
         sut.hnk_setImage(image, key: key, state: .Highlighted, format: format, success:{resultImage in
             XCTAssertTrue(resultImage.isEqualPixelByPixel(expectedImage))
@@ -188,7 +188,7 @@ class UIButton_HanekeTests: DiskTestCase {
         })
         let URL = NSURL(string: "http://haneke.io")!
         let fetcher = NetworkFetcher<UIImage>(URL: URL)
-        let expectation = self.expectationWithDescription(self.name)
+        let expectation = self.expectationWithDescription(self.name!)
         
         sut.hnk_setImageFromURL(URL, failure:{error in
             XCTAssertEqual(error!.domain, HanekeGlobals.Domain)
@@ -203,7 +203,7 @@ class UIButton_HanekeTests: DiskTestCase {
     func testSetImageFromURL_UsingFormat() {
         let image = UIImage.imageWithColor(UIColor.redColor())
         let expectedImage = UIImage.imageWithColor(UIColor.greenColor())
-        let format = Format<UIImage>(name: self.name, diskCapacity: 0) { _ in return expectedImage }
+        let format = Format<UIImage>(name: self.name!, diskCapacity: 0) { _ in return expectedImage }
         OHHTTPStubs.stubRequestsPassingTest({ _ in
             return true
             }, withStubResponse: { _ in
@@ -211,7 +211,7 @@ class UIButton_HanekeTests: DiskTestCase {
                 return OHHTTPStubsResponse(data: data!, statusCode: 200, headers:nil)
         })
         let URL = NSURL(string: "http://haneke.io")!
-        let expectation = self.expectationWithDescription(self.name)
+        let expectation = self.expectationWithDescription(self.name!)
         
         sut.hnk_setImageFromURL(URL, format: format, success:{resultImage in
             XCTAssertTrue(resultImage.isEqualPixelByPixel(expectedImage))
@@ -225,7 +225,7 @@ class UIButton_HanekeTests: DiskTestCase {
 
     func testSetImageFromFetcher_Hit_Animated_UIControlStateSelected() {
         let image = UIImage.imageWithColor(UIColor.greenColor())
-        let key = self.name
+        let key = self.name!
         let fetcher = AsyncFetcher<UIImage>(key: key, value: image)
         let expectedImage = sut.hnk_imageFormat.apply(image)
 
@@ -243,7 +243,7 @@ class UIButton_HanekeTests: DiskTestCase {
     
     func testSetImageFromFetcher_MemoryMiss_UIControlStateSelected() {
         let image = UIImage.imageWithColor(UIColor.greenColor())
-        let key = self.name
+        let key = self.name!
         let fetcher = SimpleFetcher<UIImage>(key: key, value: image)
         
         sut.hnk_setImageFromFetcher(fetcher, state: .Selected)
@@ -254,7 +254,7 @@ class UIButton_HanekeTests: DiskTestCase {
     
     func testSetImageFromFetcher_MemoryHit_UIControlStateNormal() {
         let image = UIImage.imageWithColor(UIColor.greenColor())
-        let key = self.name
+        let key = self.name!
         let fetcher = SimpleFetcher<UIImage>(key: key, value: image)
         let expectedImage = setImage(image, key: key, format: sut.hnk_imageFormat)
         
@@ -266,7 +266,7 @@ class UIButton_HanekeTests: DiskTestCase {
     
     func testSetImageFromFetcherSuccessFailure_MemoryHit_UIControlStateNormal() {
         let image = UIImage.imageWithColor(UIColor.greenColor())
-        let key = self.name
+        let key = self.name!
         let fetcher = SimpleFetcher<UIImage>(key: key, value: image)
         let cache = Shared.imageCache
         let format = sut.hnk_imageFormat
@@ -333,7 +333,7 @@ class UIButton_HanekeTests: DiskTestCase {
     
     func testSetBackgroundImage_MemoryMiss_UIControlStateNormal() {
         let image = UIImage.imageWithColor(UIColor.greenColor())
-        let key = self.name
+        let key = self.name!
         
         sut.hnk_setBackgroundImage(image, key: key)
         
@@ -343,7 +343,7 @@ class UIButton_HanekeTests: DiskTestCase {
 
     func testSetBackgroundImage_MemoryHit_UIControlStateSelected() {
         let image = UIImage.imageWithColor(UIColor.greenColor())
-        let key = self.name
+        let key = self.name!
         let expectedImage = setImage(image, key: key, format: sut.hnk_backgroundImageFormat)
         
         sut.hnk_setBackgroundImage(image, key: key, state: .Selected)
@@ -356,7 +356,7 @@ class UIButton_HanekeTests: DiskTestCase {
     func testSetBackgroundImage_UsingPlaceholder_MemoryMiss_UIControlStateDisabled() {
         let placeholder = UIImage.imageWithColor(UIColor.yellowColor())
         let image = UIImage.imageWithColor(UIColor.greenColor())
-        let key = self.name
+        let key = self.name!
         
         sut.hnk_setBackgroundImage(image, key: key, state: .Disabled, placeholder: placeholder)
         
@@ -367,7 +367,7 @@ class UIButton_HanekeTests: DiskTestCase {
     func testSetBackgroundImage_UsingPlaceholder_MemoryHit_UIControlStateNormal() {
         let placeholder = UIImage.imageWithColor(UIColor.yellowColor())
         let image = UIImage.imageWithColor(UIColor.greenColor())
-        let key = self.name
+        let key = self.name!
         let expectedImage = setImage(image, key: key, format: sut.hnk_backgroundImageFormat)
         
         sut.hnk_setBackgroundImage(image, key: key, placeholder: placeholder)
@@ -380,9 +380,9 @@ class UIButton_HanekeTests: DiskTestCase {
     func testSetBackgroundImage_UsingFormat_UIControlStateHighlighted() {
         let image = UIImage.imageWithColor(UIColor.redColor())
         let expectedImage = UIImage.imageWithColor(UIColor.greenColor())
-        let format = Format<UIImage>(name: self.name, diskCapacity: 0) { _ in return expectedImage }
-        let key = self.name
-        let expectation = self.expectationWithDescription(self.name)
+        let key = self.name!
+        let format = Format<UIImage>(name: key, diskCapacity: 0) { _ in return expectedImage }
+        let expectation = self.expectationWithDescription(key)
         
         sut.hnk_setBackgroundImage(image, key: key, state: .Highlighted, format: format, success:{resultImage in
             XCTAssertTrue(resultImage.isEqualPixelByPixel(expectedImage))
@@ -478,7 +478,7 @@ class UIButton_HanekeTests: DiskTestCase {
         })
         let URL = NSURL(string: "http://haneke.io")!
         let fetcher = NetworkFetcher<UIImage>(URL: URL)
-        let expectation = self.expectationWithDescription(self.name)
+        let expectation = self.expectationWithDescription(self.name!)
         
         sut.hnk_setBackgroundImageFromURL(URL, failure:{error in
             XCTAssertEqual(error!.domain, HanekeGlobals.Domain)
@@ -493,7 +493,7 @@ class UIButton_HanekeTests: DiskTestCase {
     func testSetBackgroundImageFromURL_UsingFormat() {
         let image = UIImage.imageWithColor(UIColor.redColor())
         let expectedImage = UIImage.imageWithColor(UIColor.greenColor())
-        let format = Format<UIImage>(name: self.name, diskCapacity: 0) { _ in return expectedImage }
+        let format = Format<UIImage>(name: self.name!, diskCapacity: 0) { _ in return expectedImage }
         OHHTTPStubs.stubRequestsPassingTest({ _ in
             return true
             }, withStubResponse: { _ in
@@ -501,7 +501,7 @@ class UIButton_HanekeTests: DiskTestCase {
                 return OHHTTPStubsResponse(data: data!, statusCode: 200, headers:nil)
         })
         let URL = NSURL(string: "http://haneke.io")!
-        let expectation = self.expectationWithDescription(self.name)
+        let expectation = self.expectationWithDescription(self.name!)
         
         sut.hnk_setBackgroundImageFromURL(URL, format: format, success:{resultImage in
             XCTAssertTrue(resultImage.isEqualPixelByPixel(expectedImage))
@@ -515,7 +515,7 @@ class UIButton_HanekeTests: DiskTestCase {
 
     func testSetBackgroundImageFromFetcher_Hit_Animated_UIControlStateSelected() {
         let image = UIImage.imageWithColor(UIColor.greenColor())
-        let key = self.name
+        let key = self.name!
         let fetcher = AsyncFetcher<UIImage>(key: key, value: image)
         let expectedImage = sut.hnk_backgroundImageFormat.apply(image)
 
@@ -533,7 +533,7 @@ class UIButton_HanekeTests: DiskTestCase {
     
     func testSetBackgroundImageFromFetcher_MemoryMiss_UIControlStateSelected() {
         let image = UIImage.imageWithColor(UIColor.greenColor())
-        let key = self.name
+        let key = self.name!
         let fetcher = SimpleFetcher<UIImage>(key: key, value: image)
         
         sut.hnk_setBackgroundImageFromFetcher(fetcher, state: .Selected)
@@ -544,7 +544,7 @@ class UIButton_HanekeTests: DiskTestCase {
     
     func testSetBackgroundImageFromFetcher_MemoryHit_UIControlStateNormal() {
         let image = UIImage.imageWithColor(UIColor.greenColor())
-        let key = self.name
+        let key = self.name!
         let fetcher = SimpleFetcher<UIImage>(key: key, value: image)
         let expectedImage = setImage(image, key: key, format: sut.hnk_backgroundImageFormat)
         
@@ -557,7 +557,7 @@ class UIButton_HanekeTests: DiskTestCase {
     
     func testSetBackgroundImageFromFetcherSuccessFailure_MemoryHit_UIControlStateNormal() {
         let image = UIImage.imageWithColor(UIColor.greenColor())
-        let key = self.name
+        let key = self.name!
         let fetcher = SimpleFetcher<UIImage>(key: key, value: image)
         let cache = Shared.imageCache
         let format = sut.hnk_backgroundImageFormat

--- a/HanekeTests/UIImage+HanekeTests.swift
+++ b/HanekeTests/UIImage+HanekeTests.swift
@@ -172,7 +172,7 @@ class UIImage_HanekeTests: XCTestCase {
         let decompressedImage = image.hnk_decompressedImage()
     
         XCTAssertNotEqual(image, decompressedImage)
-        XCTAssertTrue(decompressedImage.isEqualPixelByPixel(image), self.name)
+        XCTAssertTrue(decompressedImage.isEqualPixelByPixel(image), self.name!)
     }
     
     func _testDecompressedImageWithOrientation(orientation : ExifOrientation) {
@@ -191,7 +191,7 @@ class UIImage_HanekeTests: XCTestCase {
         let decompressedImage = image.hnk_decompressedImage()
         
         XCTAssertNotEqual(image, decompressedImage)
-        XCTAssertTrue(decompressedImage.isEqualPixelByPixel(image), self.name)
+        XCTAssertTrue(decompressedImage.isEqualPixelByPixel(image), self.name!)
     }
     
 }

--- a/HanekeTests/UIImageView+HanekeTests.swift
+++ b/HanekeTests/UIImageView+HanekeTests.swift
@@ -125,7 +125,7 @@ class UIImageView_HanekeTests: DiskTestCase {
 
     func testSetImage_MemoryMiss() {
         let image = UIImage.imageWithColor(UIColor.greenColor())
-        let key = self.name
+        let key = self.name!
         
         sut.hnk_setImage(image, key: key)
         
@@ -135,7 +135,7 @@ class UIImageView_HanekeTests: DiskTestCase {
     
     func testSetImage_MemoryHit() {
         let image = UIImage.imageWithColor(UIColor.greenColor())
-        let key = self.name
+        let key = self.name!
         let expectedImage = setImage(image, key: key)
         
         sut.hnk_setImage(image, key: key)
@@ -147,7 +147,7 @@ class UIImageView_HanekeTests: DiskTestCase {
     func testSetImage_ImageSet_MemoryMiss() {
         let previousImage = UIImage.imageWithColor(UIColor.redColor())
         let image = UIImage.imageWithColor(UIColor.greenColor())
-        let key = self.name
+        let key = self.name!
         sut.image = previousImage
         
         sut.hnk_setImage(image, key: key)
@@ -159,7 +159,7 @@ class UIImageView_HanekeTests: DiskTestCase {
     func testSetImage_UsingPlaceholder_MemoryMiss() {
         let placeholder = UIImage.imageWithColor(UIColor.yellowColor())
         let image = UIImage.imageWithColor(UIColor.greenColor())
-        let key = self.name
+        let key = self.name!
         
         sut.hnk_setImage(image, key: key, placeholder: placeholder)
         
@@ -170,7 +170,7 @@ class UIImageView_HanekeTests: DiskTestCase {
     func testSetImage_UsingPlaceholder_MemoryHit() {
         let placeholder = UIImage.imageWithColor(UIColor.yellowColor())
         let image = UIImage.imageWithColor(UIColor.greenColor())
-        let key = self.name
+        let key = self.name!
         let expectedImage = setImage(image, key: key)
         
         sut.hnk_setImage(image, key: key, placeholder: placeholder)
@@ -181,9 +181,9 @@ class UIImageView_HanekeTests: DiskTestCase {
     
     func testSetImage_Success() {
         let image = UIImage.imageWithColor(UIColor.greenColor())
-        let key = self.name
+        let key = self.name!
         sut.contentMode = .Center // No resizing
-        let expectation = self.expectationWithDescription(self.name)
+        let expectation = self.expectationWithDescription(key)
         
         sut.hnk_setImage(image, key: key, success:{resultImage in
             XCTAssertTrue(resultImage.isEqualPixelByPixel(image))
@@ -198,9 +198,9 @@ class UIImageView_HanekeTests: DiskTestCase {
     func testSetImage_UsingFormat() {
         let image = UIImage.imageWithColor(UIColor.redColor())
         let expectedImage = UIImage.imageWithColor(UIColor.greenColor())
-        let format = Format<UIImage>(name: self.name, diskCapacity: 0) { _ in return expectedImage }
-        let key = self.name
-        let expectation = self.expectationWithDescription(self.name)
+        let key = self.name!
+        let format = Format<UIImage>(name: key, diskCapacity: 0) { _ in return expectedImage }
+        let expectation = self.expectationWithDescription(key)
         
         sut.hnk_setImage(image, key: key, format: format, success:{resultImage in
             XCTAssertTrue(resultImage.isEqualPixelByPixel(expectedImage))
@@ -214,7 +214,7 @@ class UIImageView_HanekeTests: DiskTestCase {
 
     func testSetImageFromFetcher_MemoryMiss() {
         let image = UIImage.imageWithColor(UIColor.greenColor())
-        let key = self.name
+        let key = self.name!
         let fetcher = SimpleFetcher<UIImage>(key: key, value: image)
         
         sut.hnk_setImageFromFetcher(fetcher)
@@ -225,7 +225,7 @@ class UIImageView_HanekeTests: DiskTestCase {
     
     func testSetImageFromFetcher_MemoryHit() {
         let image = UIImage.imageWithColor(UIColor.greenColor())
-        let key = self.name
+        let key = self.name!
         let fetcher = SimpleFetcher<UIImage>(key: key, value: image)
         let expectedImage = setImage(image, key: key)
         
@@ -237,7 +237,7 @@ class UIImageView_HanekeTests: DiskTestCase {
 
     func testSetImageFromFetcher_Hit_Animated() {
         let image = UIImage.imageWithColor(UIColor.greenColor())
-        let key = self.name
+        let key = self.name!
         let fetcher = AsyncFetcher<UIImage>(key: key, value: image)
         let expectedImage = sut.hnk_format.apply(image)
 
@@ -256,7 +256,7 @@ class UIImageView_HanekeTests: DiskTestCase {
     func testSetImageFromFetcher_ImageSet_MemoryMiss() {
         let previousImage = UIImage.imageWithColor(UIColor.redColor())
         let image = UIImage.imageWithColor(UIColor.greenColor())
-        let key = self.name
+        let key = self.name!
         let fetcher = SimpleFetcher<UIImage>(key: key, value: image)
         sut.image = previousImage
         
@@ -269,7 +269,7 @@ class UIImageView_HanekeTests: DiskTestCase {
     func testSetImageFromFetcher_UsingPlaceholder_MemoryMiss() {
         let placeholder = UIImage.imageWithColor(UIColor.yellowColor())
         let image = UIImage.imageWithColor(UIColor.greenColor())
-        let key = self.name
+        let key = self.name!
         let fetcher = SimpleFetcher<UIImage>(key: key, value: image)
         
         sut.hnk_setImageFromFetcher(fetcher, placeholder:placeholder)
@@ -281,7 +281,7 @@ class UIImageView_HanekeTests: DiskTestCase {
     func testSetImageFromFetcher_UsingPlaceholder_MemoryHit() {
         let placeholder = UIImage.imageWithColor(UIColor.yellowColor())
         let image = UIImage.imageWithColor(UIColor.greenColor())
-        let key = self.name
+        let key = self.name!
         let fetcher = SimpleFetcher<UIImage>(key: key, value: image)
         let expectedImage = setImage(image, key: key)
         
@@ -293,10 +293,10 @@ class UIImageView_HanekeTests: DiskTestCase {
     
     func testSetImageFromFetcher_Success() {
         let image = UIImage.imageWithColor(UIColor.greenColor())
-        let key = self.name
+        let key = self.name!
         let fetcher = SimpleFetcher<UIImage>(key: key, value: image)
         sut.contentMode = .Center // No resizing
-        let expectation = self.expectationWithDescription(self.name)
+        let expectation = self.expectationWithDescription(key)
         
         sut.hnk_setImageFromFetcher(fetcher, success: { resultImage in
             XCTAssertTrue(resultImage.isEqualPixelByPixel(image))
@@ -309,9 +309,9 @@ class UIImageView_HanekeTests: DiskTestCase {
     }
     
     func testSetImageFromFetcher_Failure() {
-        let key = self.name
-        let fetcher = MockFetcher<UIImage>(key:key)
-        let expectation = self.expectationWithDescription(self.name)
+        let key = self.name!
+        let fetcher = MockFetcher<UIImage>(key: key)
+        let expectation = self.expectationWithDescription(key)
         
         sut.hnk_setImageFromFetcher(fetcher, failure: {error in
             XCTAssertEqual(error!.domain, HanekeGlobals.Domain)
@@ -326,10 +326,10 @@ class UIImageView_HanekeTests: DiskTestCase {
     func testSetImageFromFetcher_UsingFormat() {
         let image = UIImage.imageWithColor(UIColor.redColor())
         let expectedImage = UIImage.imageWithColor(UIColor.greenColor())
-        let format = Format<UIImage>(name: self.name, diskCapacity: 0) { _ in return expectedImage }
-        let key = self.name
+        let key = self.name!
+        let format = Format<UIImage>(name: key, diskCapacity: 0) { _ in return expectedImage }
         let fetcher = SimpleFetcher<UIImage>(key: key, value: image)
-        let expectation = self.expectationWithDescription(self.name)
+        let expectation = self.expectationWithDescription(key)
         
         sut.hnk_setImageFromFetcher(fetcher, format: format, success: { resultImage in
             XCTAssertTrue(resultImage.isEqualPixelByPixel(expectedImage))
@@ -444,7 +444,7 @@ class UIImageView_HanekeTests: DiskTestCase {
         let URL = NSURL(string: "http://haneke.io")!
         let fetcher = NetworkFetcher<UIImage>(URL: URL)
         sut.contentMode = .Center // No resizing
-        let expectation = self.expectationWithDescription(self.name)
+        let expectation = self.expectationWithDescription(self.name!)
         
         sut.hnk_setImageFromURL(URL, success:{resultImage in
             XCTAssertTrue(resultImage.isEqualPixelByPixel(image))
@@ -473,7 +473,7 @@ class UIImageView_HanekeTests: DiskTestCase {
         })
         let URL2 = NSURL(string: "http://haneke.io/2.png")!
         let fetcher2 = NetworkFetcher<UIImage>(URL: URL2)
-        let expectation = self.expectationWithDescription(self.name)
+        let expectation = self.expectationWithDescription(self.name!)
         
         sut.hnk_setImageFromURL(URL2, success:{resultImage in
             XCTAssertTrue(resultImage.isEqualPixelByPixel(image))
@@ -494,7 +494,7 @@ class UIImageView_HanekeTests: DiskTestCase {
         })
         let URL = NSURL(string: "http://haneke.io")!
         let fetcher = NetworkFetcher<UIImage>(URL: URL)
-        let expectation = self.expectationWithDescription(self.name)
+        let expectation = self.expectationWithDescription(self.name!)
         
         sut.hnk_setImageFromURL(URL, failure:{error in
             XCTAssertEqual(error!.domain, HanekeGlobals.Domain)
@@ -509,7 +509,7 @@ class UIImageView_HanekeTests: DiskTestCase {
     func testSetImageFromURL_UsingFormat() {
         let image = UIImage.imageWithColor(UIColor.redColor())
         let expectedImage = UIImage.imageWithColor(UIColor.greenColor())
-        let format = Format<UIImage>(name: self.name, diskCapacity: 0) { _ in return expectedImage }
+        let format = Format<UIImage>(name: self.name!, diskCapacity: 0) { _ in return expectedImage }
         OHHTTPStubs.stubRequestsPassingTest({ _ in
             return true
             }, withStubResponse: { _ in
@@ -517,7 +517,7 @@ class UIImageView_HanekeTests: DiskTestCase {
                 return OHHTTPStubsResponse(data: data!, statusCode: 200, headers:nil)
         })
         let URL = NSURL(string: "http://haneke.io")!
-        let expectation = self.expectationWithDescription(self.name)
+        let expectation = self.expectationWithDescription(self.name!)
         
         sut.hnk_setImageFromURL(URL, format: format, success:{resultImage in
             XCTAssertTrue(resultImage.isEqualPixelByPixel(expectedImage))


### PR DESCRIPTION
This PR fixes all the build warnings/errors necessary to build with Xcode 7.3 and Swift 2.2

The biggest change here is that now the `name` property of `XCTest` is a `String?`. The fix for this was to implicitly unwrap it for the tests.

After these changes I have successfully run the tests with no failures on my machine. I would also suggest long term pulling in [CryptoSwift](https://github.com/krzyzanowskim/CryptoSwift) as a dependency, rather than copying the code, which I've had to modify here as well.