### PR TITLE
[Cache] Added size property to get the total size of cache located on…

### DIFF
--- a/Haneke/Cache.swift
+++ b/Haneke/Cache.swift
@@ -157,6 +157,16 @@ public class Cache<T: DataConvertible where T.Result == T, T : DataRepresentable
         }
     }
 
+    // MARK: Size
+
+    public var size: UInt64 {
+        var size: UInt64 = 0
+        for (_, (_, _, diskCache)) in self.formats {
+            dispatch_sync(diskCache.cacheQueue) { size += diskCache.size }
+        }
+        return size
+    }
+
     // MARK: Notifications
     
     func onMemoryWarning() {


### PR DESCRIPTION
… disk

**Description:**
Although both `DiskCache` and its `size` property are marked as "public", for now there is no way to get the total size of disk space used by `Cache`. I propose adding public property `size` to fix this issue.

**Related issues:**
https://github.com/Haneke/HanekeSwift/issues/219 - describes the same problem.
https://github.com/Haneke/HanekeSwift/pull/292 - being able to use custom `DiskCache` will also allow to get the total size of space being used on disk.

Looking forward for any comments and suggestions.