### PR TITLE
Wrapping reading attributes in try-catch block.

### DIFF
--- a/Haneke/DiskCache.swift
+++ b/Haneke/DiskCache.swift
@@ -169,7 +169,13 @@ public class DiskCache {
     private func setDataSync(data: NSData, key: String) {
         let path = self.pathForKey(key)
         let fileManager = NSFileManager.defaultManager()
-        let previousAttributes : NSDictionary? = try? fileManager.attributesOfItemAtPath(path)
+        
+        var previousAttributes : NSDictionary?
+        do {
+            try previousAttributes = fileManager.attributesOfItemAtPath(path)
+        } catch {
+            Log.error("Attributes of item at path not found: \(error)", error as NSError)
+        }
         
         do {
             try data.writeToFile(path, options: NSDataWritingOptions.AtomicWrite)


### PR DESCRIPTION
During debugging the app, I spotted this leak:
<img width="1027" alt="haneke leak" src="https://cloud.githubusercontent.com/assets/5917582/14529775/6b5e2936-0256-11e6-93b3-9ef8d6f65f51.png">
After double-clicking on the first line I was redirected to `private func setDataSync(data: NSData, key: String)` method of `DiskCache`, specifically to:
 `let previousAttributes : NSDictionary? = try? fileManager.attributesOfItemAtPath(path)`.
I wrapped it up into `try-catch` block, run Instruments again and the leak was gone. Then I restored `setDataSync` method to original version -> leak. Again, back to `try-catch` -> no leak.
Now although it fixes leak it would be cool if someone could explain to me why and what is happening, because AFAIK not catched exception should not cause such situation. 🙄  

Codebase of app is migrated to Swift 2.2, leak was spotted with using Xcode 7.3, iOS 9.3 on both device and simulator. 