### PR TITLE
Add the ability to prevent overwriting when adding a format

### DIFF
--- a/Haneke/Cache.swift
+++ b/Haneke/Cache.swift
@@ -179,7 +179,11 @@ public class Cache<T: DataConvertible where T.Result == T, T : DataRepresentable
 
     var formats : [String : (Format<T>, NSCache, DiskCache)] = [:]
     
-    public func addFormat(format : Format<T>) {
+    public func addFormat(format : Format<T>, overwrite: Bool = true) {
+        if overwrite == false && self.formats[format.name] != nil {
+            return
+        }
+        
         let name = format.name
         let formatPath = self.formatPath(formatName: name)
         let memoryCache = NSCache()


### PR DESCRIPTION
I am manually adding a format and would like to ensure that I only add it when it does not already exist. 

Since `self.formats[name]` is not publicly available, I figured it made the most sense to add an `overwrite` boolean that defaults to `true` (for backwards compatibility). 

Setting `overwrite = false` will ***only*** add the format if it doesn't already exist. Otherwise, it does nothing.