### PR TITLE
Convert to Swift 3 with minor changes of internal methods to conform to Swift 3 syntax

### DIFF
--- a/Haneke.playground/contents.xcplayground
+++ b/Haneke.playground/contents.xcplayground
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<playground version='3.0' sdk='iphonesimulator' auto-termination-delay='100' runInFullSimulator='YES'>
+<playground version='3.0' sdk='iphonesimulator' auto-termination-delay='100'>
     <sections>
         <code source-file-name='section-1.swift'/>
     </sections>

--- a/Haneke.playground/section-1.swift
+++ b/Haneke.playground/section-1.swift
@@ -3,7 +3,7 @@ import Haneke
 
 /// Initialize a JSON cache and fetch/cache a JSON response.
 func example1() {
-    let cache = Cache<JSON>(name: "github")
+    let cache = HanekeCache<JSON>(name: "github")
     let URL = NSURL(string: "https://api.github.com/users/haneke")!
     
     cache.fetch(URL: URL).onSuccess { JSON in

--- a/Haneke.playground/section-1.swift
+++ b/Haneke.playground/section-1.swift
@@ -1,32 +1,32 @@
-// Open this playground from the Haneke workspace after building the Haneke framework. See: http://stackoverflow.com/a/24049021/143378
-import Haneke
-
-/// Initialize a JSON cache and fetch/cache a JSON response.
-func example1() {
-    let cache = HanekeCache<JSON>(name: "github")
-    let URL = NSURL(string: "https://api.github.com/users/haneke")!
-    
-    cache.fetch(URL: URL).onSuccess { JSON in
-        print(JSON.dictionary?["bio"])
-    }
-}
-
-/// Set a image view image from a url using the shared image cache and resizing.
-func example2() {
-    let imageView = UIImageView(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
-    let URL = NSURL(string: "https://avatars.githubusercontent.com/u/8600207?v=2")!
-
-    imageView.hnk_setImageFromURL(URL)
-}
-
-/// Set and fetch data from the shared data cache
-func example3() {
-    let cache = Shared.dataCache
-    let data = "SGVscCEgSSdtIHRyYXBwZWQgaW4gYSBCYXNlNjQgc3RyaW5nIQ==".asData()
-    
-    cache.set(value: data, key: "secret")
-    
-    cache.fetch(key: "secret").onSuccess { data in
-        print(NSString(data:data, encoding:NSUTF8StringEncoding))
-    }
-}
+//// Open this playground from the Haneke workspace after building the Haneke framework. See: http://stackoverflow.com/a/24049021/143378
+//import Haneke
+//
+///// Initialize a JSON cache and fetch/cache a JSON response.
+//func example1() {
+//    let cache = Cache<JSON>(name: "github")
+//    let URL = URL(string: "https://api.github.com/users/haneke")!
+//    
+//    cache.fetch(URL: URL).onSuccess { JSON in
+//        print(JSON.dictionary?["bio"])
+//    }
+//}
+//
+///// Set a image view image from a url using the shared image cache and resizing.
+//func example2() {
+//    let imageView = UIImageView(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
+//    let URL = NSURL(string: "https://avatars.githubusercontent.com/u/8600207?v=2")!
+//
+//    imageView.hnk_setImageFromURL(URL)
+//}
+//
+///// Set and fetch data from the shared data cache
+//func example3() {
+//    let cache = Shared.dataCache
+//    let data = "SGVscCEgSSdtIHRyYXBwZWQgaW4gYSBCYXNlNjQgc3RyaW5nIQ==".asData()
+//    
+//    cache.set(value: data, key: "secret")
+//    
+//    cache.fetch(key: "secret").onSuccess { data in
+//        print(NSString(data:data, encoding:NSUTF8StringEncoding))
+//    }
+//}

--- a/Haneke.playground/timeline.xctimeline
+++ b/Haneke.playground/timeline.xctimeline
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<Timeline
-   version = "3.0">
-   <TimelineItems>
-   </TimelineItems>
-</Timeline>

--- a/Haneke.xcodeproj/project.pbxproj
+++ b/Haneke.xcodeproj/project.pbxproj
@@ -22,7 +22,7 @@
 		6393C5E51C3B229200EB1FD8 /* CGSize+Swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36BB64F419BECE1E006A1309 /* CGSize+Swift.swift */; };
 		6393C5E61C3B229200EB1FD8 /* Fetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = A03F7E8119BF94AA0002511F /* Fetcher.swift */; };
 		6393C5E71C3B229200EB1FD8 /* NSHTTPURLResponse+Haneke.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87BCE4731C37632A0040B92C /* NSHTTPURLResponse+Haneke.swift */; };
-		6393C5E81C3B229200EB1FD8 /* Cache.swift in Sources */ = {isa = PBXBuildFile; fileRef = A095C972198041D100CD0F4C /* Cache.swift */; };
+		6393C5E81C3B229200EB1FD8 /* HanekeCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = A095C972198041D100CD0F4C /* HanekeCache.swift */; };
 		6393C5E91C3B229200EB1FD8 /* UIImage+Haneke.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0D7D6831997B2EC000CAF46 /* UIImage+Haneke.swift */; };
 		6393C5EA1C3B229200EB1FD8 /* DiskFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C0D39C519CF4CB900452BC4 /* DiskFetcher.swift */; };
 		6393C5EB1C3B229200EB1FD8 /* Log.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0985E5B1A10810500691636 /* Log.swift */; };
@@ -66,7 +66,7 @@
 		A06EE28219B18FE600572D17 /* String+HanekeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A06EE28119B18FE600572D17 /* String+HanekeTests.swift */; };
 		A0720DEA19EF2AB2000FEE83 /* CryptoSwiftMD5.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0720DE919EF2AB2000FEE83 /* CryptoSwiftMD5.swift */; };
 		A095C95C1980418C00CD0F4C /* Haneke.h in Headers */ = {isa = PBXBuildFile; fileRef = A095C95B1980418C00CD0F4C /* Haneke.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A095C973198041D100CD0F4C /* Cache.swift in Sources */ = {isa = PBXBuildFile; fileRef = A095C972198041D100CD0F4C /* Cache.swift */; };
+		A095C973198041D100CD0F4C /* HanekeCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = A095C972198041D100CD0F4C /* HanekeCache.swift */; };
 		A095C975198045D200CD0F4C /* CacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A095C974198045D200CD0F4C /* CacheTests.swift */; };
 		A0985E5C1A10810500691636 /* Log.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0985E5B1A10810500691636 /* Log.swift */; };
 		A0C6BA3A19AC0D1E007111E9 /* NSFileManager+Haneke.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0C6BA3919AC0D1E007111E9 /* NSFileManager+Haneke.swift */; };
@@ -151,7 +151,7 @@
 		A095C95B1980418C00CD0F4C /* Haneke.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Haneke.h; sourceTree = "<group>"; };
 		A095C9611980418C00CD0F4C /* HanekeTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = HanekeTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		A095C9671980418C00CD0F4C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		A095C972198041D100CD0F4C /* Cache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Cache.swift; sourceTree = "<group>"; };
+		A095C972198041D100CD0F4C /* HanekeCache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HanekeCache.swift; sourceTree = "<group>"; };
 		A095C974198045D200CD0F4C /* CacheTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CacheTests.swift; sourceTree = "<group>"; };
 		A0985E5B1A10810500691636 /* Log.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Log.swift; sourceTree = "<group>"; };
 		A0C6BA3919AC0D1E007111E9 /* NSFileManager+Haneke.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSFileManager+Haneke.swift"; sourceTree = "<group>"; };
@@ -295,7 +295,7 @@
 		A095C9581980418C00CD0F4C /* Haneke */ = {
 			isa = PBXGroup;
 			children = (
-				A095C972198041D100CD0F4C /* Cache.swift */,
+				A095C972198041D100CD0F4C /* HanekeCache.swift */,
 				A0720DE519EF2A73000FEE83 /* CryptoSwift */,
 				A0E8BFDB19CCAE1D00A4E2B0 /* Data.swift */,
 				A0D7D68019978F9A000CAF46 /* DiskCache.swift */,
@@ -484,14 +484,19 @@
 				LastUpgradeCheck = 0700;
 				ORGANIZATIONNAME = Haneke;
 				TargetAttributes = {
+					6393C5DA1C3B229200EB1FD8 = {
+						LastSwiftMigration = 0800;
+					};
 					A0026E9919C9BFBC004DE0C6 = {
 						CreatedOnToolsVersion = 6.0;
 					};
 					A095C9551980418C00CD0F4C = {
 						CreatedOnToolsVersion = 6.0;
+						LastSwiftMigration = 0800;
 					};
 					A095C9601980418C00CD0F4C = {
 						CreatedOnToolsVersion = 6.0;
+						LastSwiftMigration = 0800;
 						TestTargetID = A095C9551980418C00CD0F4C;
 					};
 				};
@@ -585,7 +590,7 @@
 				6393C5E51C3B229200EB1FD8 /* CGSize+Swift.swift in Sources */,
 				6393C5E61C3B229200EB1FD8 /* Fetcher.swift in Sources */,
 				6393C5E71C3B229200EB1FD8 /* NSHTTPURLResponse+Haneke.swift in Sources */,
-				6393C5E81C3B229200EB1FD8 /* Cache.swift in Sources */,
+				6393C5E81C3B229200EB1FD8 /* HanekeCache.swift in Sources */,
 				6393C5E91C3B229200EB1FD8 /* UIImage+Haneke.swift in Sources */,
 				6393C5EA1C3B229200EB1FD8 /* DiskFetcher.swift in Sources */,
 				6393C5EB1C3B229200EB1FD8 /* Log.swift in Sources */,
@@ -622,7 +627,7 @@
 				36BB64F519BECE1E006A1309 /* CGSize+Swift.swift in Sources */,
 				A03F7E8219BF94AA0002511F /* Fetcher.swift in Sources */,
 				87BCE4741C37632A0040B92C /* NSHTTPURLResponse+Haneke.swift in Sources */,
-				A095C973198041D100CD0F4C /* Cache.swift in Sources */,
+				A095C973198041D100CD0F4C /* HanekeCache.swift in Sources */,
 				A0D7D6841997B2EC000CAF46 /* UIImage+Haneke.swift in Sources */,
 				8C0D39C619CF4CB900452BC4 /* DiskFetcher.swift in Sources */,
 				A0985E5C1A10810500691636 /* Log.swift in Sources */,
@@ -719,6 +724,7 @@
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 			};
@@ -740,6 +746,7 @@
 				PRODUCT_NAME = Haneke;
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 			};
@@ -873,6 +880,7 @@
 				PRODUCT_NAME = Haneke;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -891,6 +899,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = io.haneke.Haneke;
 				PRODUCT_NAME = Haneke;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -913,6 +922,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "HanekeTests/HanekeTests-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -930,6 +940,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "io.haneke.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "HanekeTests/HanekeTests-Bridging-Header.h";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};

--- a/Haneke.xcodeproj/project.pbxproj
+++ b/Haneke.xcodeproj/project.pbxproj
@@ -22,7 +22,7 @@
 		6393C5E51C3B229200EB1FD8 /* CGSize+Swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36BB64F419BECE1E006A1309 /* CGSize+Swift.swift */; };
 		6393C5E61C3B229200EB1FD8 /* Fetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = A03F7E8119BF94AA0002511F /* Fetcher.swift */; };
 		6393C5E71C3B229200EB1FD8 /* NSHTTPURLResponse+Haneke.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87BCE4731C37632A0040B92C /* NSHTTPURLResponse+Haneke.swift */; };
-		6393C5E81C3B229200EB1FD8 /* HanekeCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = A095C972198041D100CD0F4C /* HanekeCache.swift */; };
+		6393C5E81C3B229200EB1FD8 /* Cache.swift in Sources */ = {isa = PBXBuildFile; fileRef = A095C972198041D100CD0F4C /* Cache.swift */; };
 		6393C5E91C3B229200EB1FD8 /* UIImage+Haneke.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0D7D6831997B2EC000CAF46 /* UIImage+Haneke.swift */; };
 		6393C5EA1C3B229200EB1FD8 /* DiskFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C0D39C519CF4CB900452BC4 /* DiskFetcher.swift */; };
 		6393C5EB1C3B229200EB1FD8 /* Log.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0985E5B1A10810500691636 /* Log.swift */; };
@@ -66,7 +66,7 @@
 		A06EE28219B18FE600572D17 /* String+HanekeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A06EE28119B18FE600572D17 /* String+HanekeTests.swift */; };
 		A0720DEA19EF2AB2000FEE83 /* CryptoSwiftMD5.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0720DE919EF2AB2000FEE83 /* CryptoSwiftMD5.swift */; };
 		A095C95C1980418C00CD0F4C /* Haneke.h in Headers */ = {isa = PBXBuildFile; fileRef = A095C95B1980418C00CD0F4C /* Haneke.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A095C973198041D100CD0F4C /* HanekeCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = A095C972198041D100CD0F4C /* HanekeCache.swift */; };
+		A095C973198041D100CD0F4C /* Cache.swift in Sources */ = {isa = PBXBuildFile; fileRef = A095C972198041D100CD0F4C /* Cache.swift */; };
 		A095C975198045D200CD0F4C /* CacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A095C974198045D200CD0F4C /* CacheTests.swift */; };
 		A0985E5C1A10810500691636 /* Log.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0985E5B1A10810500691636 /* Log.swift */; };
 		A0C6BA3A19AC0D1E007111E9 /* NSFileManager+Haneke.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0C6BA3919AC0D1E007111E9 /* NSFileManager+Haneke.swift */; };
@@ -151,7 +151,7 @@
 		A095C95B1980418C00CD0F4C /* Haneke.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Haneke.h; sourceTree = "<group>"; };
 		A095C9611980418C00CD0F4C /* HanekeTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = HanekeTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		A095C9671980418C00CD0F4C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		A095C972198041D100CD0F4C /* HanekeCache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HanekeCache.swift; sourceTree = "<group>"; };
+		A095C972198041D100CD0F4C /* Cache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Cache.swift; sourceTree = "<group>"; };
 		A095C974198045D200CD0F4C /* CacheTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CacheTests.swift; sourceTree = "<group>"; };
 		A0985E5B1A10810500691636 /* Log.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Log.swift; sourceTree = "<group>"; };
 		A0C6BA3919AC0D1E007111E9 /* NSFileManager+Haneke.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSFileManager+Haneke.swift"; sourceTree = "<group>"; };
@@ -295,7 +295,7 @@
 		A095C9581980418C00CD0F4C /* Haneke */ = {
 			isa = PBXGroup;
 			children = (
-				A095C972198041D100CD0F4C /* HanekeCache.swift */,
+				A095C972198041D100CD0F4C /* Cache.swift */,
 				A0720DE519EF2A73000FEE83 /* CryptoSwift */,
 				A0E8BFDB19CCAE1D00A4E2B0 /* Data.swift */,
 				A0D7D68019978F9A000CAF46 /* DiskCache.swift */,
@@ -489,6 +489,7 @@
 					};
 					A0026E9919C9BFBC004DE0C6 = {
 						CreatedOnToolsVersion = 6.0;
+						LastSwiftMigration = 0800;
 					};
 					A095C9551980418C00CD0F4C = {
 						CreatedOnToolsVersion = 6.0;
@@ -590,7 +591,7 @@
 				6393C5E51C3B229200EB1FD8 /* CGSize+Swift.swift in Sources */,
 				6393C5E61C3B229200EB1FD8 /* Fetcher.swift in Sources */,
 				6393C5E71C3B229200EB1FD8 /* NSHTTPURLResponse+Haneke.swift in Sources */,
-				6393C5E81C3B229200EB1FD8 /* HanekeCache.swift in Sources */,
+				6393C5E81C3B229200EB1FD8 /* Cache.swift in Sources */,
 				6393C5E91C3B229200EB1FD8 /* UIImage+Haneke.swift in Sources */,
 				6393C5EA1C3B229200EB1FD8 /* DiskFetcher.swift in Sources */,
 				6393C5EB1C3B229200EB1FD8 /* Log.swift in Sources */,
@@ -627,7 +628,7 @@
 				36BB64F519BECE1E006A1309 /* CGSize+Swift.swift in Sources */,
 				A03F7E8219BF94AA0002511F /* Fetcher.swift in Sources */,
 				87BCE4741C37632A0040B92C /* NSHTTPURLResponse+Haneke.swift in Sources */,
-				A095C973198041D100CD0F4C /* HanekeCache.swift in Sources */,
+				A095C973198041D100CD0F4C /* Cache.swift in Sources */,
 				A0D7D6841997B2EC000CAF46 /* UIImage+Haneke.swift in Sources */,
 				8C0D39C619CF4CB900452BC4 /* DiskFetcher.swift in Sources */,
 				A0985E5C1A10810500691636 /* Log.swift in Sources */,
@@ -764,6 +765,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "io.haneke.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -775,6 +777,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "io.haneke.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};

--- a/Haneke.xcworkspace/xcshareddata/Haneke.xcscmblueprint
+++ b/Haneke.xcworkspace/xcshareddata/Haneke.xcscmblueprint
@@ -10,7 +10,7 @@
   "DVTSourceControlWorkspaceBlueprintIdentifierKey" : "D9D86AAE-952B-48A9-A2AB-D2832C98D4A1",
   "DVTSourceControlWorkspaceBlueprintWorkingCopyPathsKey" : {
     "38C2A0D4F62B675E8C16C8BC1437C7753846C8AC" : "HanekeSwiftHanekeTests\/Submodules\/OHHTTPStubs",
-    "C93564C1AFB8B50FF58188F21182F5D0EEAD1C3F" : "HanekeSwift"
+    "C93564C1AFB8B50FF58188F21182F5D0EEAD1C3F" : "HanekeSwift\/"
   },
   "DVTSourceControlWorkspaceBlueprintNameKey" : "Haneke",
   "DVTSourceControlWorkspaceBlueprintVersion" : 204,

--- a/Haneke/CGSize+Swift.swift
+++ b/Haneke/CGSize+Swift.swift
@@ -10,16 +10,16 @@ import UIKit
 
 extension CGSize {
 
-    func hnk_aspectFillSize(size: CGSize) -> CGSize {
+    func hnk_aspectFillSize(_ size: CGSize) -> CGSize {
         let scaleWidth = size.width / self.width
         let scaleHeight = size.height / self.height
         let scale = max(scaleWidth, scaleHeight)
 
-        let resultSize = CGSizeMake(self.width * scale, self.height * scale)
-        return CGSizeMake(ceil(resultSize.width), ceil(resultSize.height))
+        let resultSize = CGSize(width: self.width * scale, height: self.height * scale)
+        return CGSize(width: ceil(resultSize.width), height: ceil(resultSize.height))
     }
 
-    func hnk_aspectFitSize(size: CGSize) -> CGSize {
+    func hnk_aspectFitSize(_ size: CGSize) -> CGSize {
         let targetAspect = size.width / size.height
         let sourceAspect = self.width / self.height
         var resultSize = size
@@ -30,6 +30,6 @@ extension CGSize {
         else {
             resultSize.height = size.width / sourceAspect
         }
-        return CGSizeMake(ceil(resultSize.width), ceil(resultSize.height))
+        return CGSize(width: ceil(resultSize.width), height: ceil(resultSize.height))
     }
 }

--- a/Haneke/Cache.swift
+++ b/Haneke/Cache.swift
@@ -33,8 +33,8 @@ extension HanekeGlobals {
     
 }
 
-// In order to not conflict with upcoming `Cache` naming convention for Swift3, name changed to HanekeCache
-open class HanekeCache<T: DataConvertible> where T.Result == T, T : DataRepresentable {
+// In order to not conflict with upcoming `Cache` naming convention for Swift3, name changed to Cache
+open class Cache<T: DataConvertible> where T.Result == T, T : DataRepresentable {
     
     let name: String
     
@@ -77,7 +77,7 @@ open class HanekeCache<T: DataConvertible> where T.Result == T, T : DataRepresen
     }
     
     open func fetch(key: String, formatName: String = HanekeGlobals.Cache.OriginalFormatName, failure fail : Fetch<T>.Failer? = nil, success succeed : Fetch<T>.Succeeder? = nil) -> Fetch<T> {
-        let fetch = HanekeCache.buildFetch(failure: fail, success: succeed)
+        let fetch = Cache.buildFetch(failure: fail, success: succeed)
         if let (format, memoryCache, diskCache) = self.formats[formatName] {
             if let wrapper = memoryCache.object(forKey: key as AnyObject) as? ObjectWrapper, let result = wrapper.hnk_value as? T {
                 fetch.succeed(result)
@@ -102,7 +102,7 @@ open class HanekeCache<T: DataConvertible> where T.Result == T, T : DataRepresen
     
     open func fetch(fetcher : Fetcher<T>, formatName: String = HanekeGlobals.Cache.OriginalFormatName, failure fail : Fetch<T>.Failer? = nil, success succeed : Fetch<T>.Succeeder? = nil) -> Fetch<T> {
         let key = fetcher.key
-        let fetch = HanekeCache.buildFetch(failure: fail, success: succeed)
+        let fetch = Cache.buildFetch(failure: fail, success: succeed)
         self.fetch(key: key, formatName: formatName, failure: { error in
             if (error as? NSError)?.code == HanekeGlobals.Cache.ErrorCode.formatNotFound.rawValue {
                 fetch.fail(error)

--- a/Haneke/Cache.swift
+++ b/Haneke/Cache.swift
@@ -33,7 +33,6 @@ extension HanekeGlobals {
     
 }
 
-// In order to not conflict with upcoming `Cache` naming convention for Swift3, name changed to Cache
 open class Cache<T: DataConvertible> where T.Result == T, T : DataRepresentable {
     
     let name: String

--- a/Haneke/CryptoSwiftMD5.swift
+++ b/Haneke/CryptoSwiftMD5.swift
@@ -24,7 +24,7 @@ Permission is granted to anyone to use this software for any purpose,including c
 import Foundation
 
 /** array of bytes, little-endian representation */
-func arrayOfBytes<T>(value:T, length:Int? = nil) -> Array<UInt8> {
+func arrayOfBytes<T>(value:T, length:Int? = nil) -> [UInt8] {
     let totalBytes = length ?? MemoryLayout<T>.size
     
     let valuePointer = UnsafeMutablePointer<T>.allocate(capacity: 1)
@@ -61,7 +61,7 @@ extension NSMutableData {
 
 struct BytesSequence: Sequence {
     let chunkSize: Int
-    let data: Array<UInt8>
+    let data: [UInt8]
     
     func makeIterator() -> AnyIterator<ArraySlice<UInt8>> {
         var offset:Int = 0
@@ -77,14 +77,14 @@ struct BytesSequence: Sequence {
 class HashBase {
     
     static let size:Int = 16 // 128 / 8
-    let message: Array<UInt8>
+    let message: [UInt8]
     
-    init (_ message: Array<UInt8>) {
+    init (_ message: [UInt8]) {
         self.message = message
     }
     
     /** Common part for hash calculation. Prepare header data. */
-    func prepare(_ len:Int) -> Array<UInt8> {
+    func prepare(_ len:Int) -> [UInt8] {
         var tmpMessage = message
         
         // Step 1. Append Padding Bits
@@ -108,8 +108,8 @@ func rotateLeft(v: UInt32, n: UInt32) -> UInt32 {
     return ((v << n) & 0xFFFFFFFF) | (v >> (32 - n))
 }
 
-func sliceToUInt32Array(_ slice: ArraySlice<UInt8>) -> Array<UInt32> {
-    var result = Array<UInt32>()
+func sliceToUInt32Array(_ slice: ArraySlice<UInt8>) -> [UInt32] {
+    var result = [UInt32]()
     result.reserveCapacity(16)
     for idx in stride(from: slice.startIndex, to: slice.endIndex, by: MemoryLayout<UInt32>.size) {
         let val1:UInt32 = (UInt32(slice[idx.advanced(by: 3)]) << 24)
@@ -126,13 +126,13 @@ class MD5 : HashBase {
     
     
     /** specifies the per-round shift amounts */
-    private let s: Array<UInt32> = [7, 12, 17, 22,  7, 12, 17, 22,  7, 12, 17, 22,  7, 12, 17, 22,
+    private let s: [UInt32] = [7, 12, 17, 22,  7, 12, 17, 22,  7, 12, 17, 22,  7, 12, 17, 22,
                                     5,  9, 14, 20,  5,  9, 14, 20,  5,  9, 14, 20,  5,  9, 14, 20,
                                     4, 11, 16, 23,  4, 11, 16, 23,  4, 11, 16, 23,  4, 11, 16, 23,
                                     6, 10, 15, 21,  6, 10, 15, 21,  6, 10, 15, 21,  6, 10, 15, 21]
     
     /** binary integer part of the sines of integers (Radians) */
-    private let k: Array<UInt32> = [0xd76aa478,0xe8c7b756,0x242070db,0xc1bdceee,
+    private let k: [UInt32] = [0xd76aa478,0xe8c7b756,0x242070db,0xc1bdceee,
                                     0xf57c0faf,0x4787c62a,0xa8304613,0xfd469501,
                                     0x698098d8,0x8b44f7af,0xffff5bb1,0x895cd7be,
                                     0x6b901122,0xfd987193,0xa679438e,0x49b40821,
@@ -149,9 +149,9 @@ class MD5 : HashBase {
                                     0x6fa87e4f,0xfe2ce6e0,0xa3014314,0x4e0811a1,
                                     0xf7537e82,0xbd3af235,0x2ad7d2bb,0xeb86d391]
     
-    private let h:Array<UInt32> = [0x67452301, 0xefcdab89, 0x98badcfe, 0x10325476]
+    private let h: [UInt32] = [0x67452301, 0xefcdab89, 0x98badcfe, 0x10325476]
     
-    func calculate() -> Array<UInt8> {
+    func calculate() -> [UInt8] {
         var tmpMessage = prepare(64)
         tmpMessage.reserveCapacity(tmpMessage.count + 4)
         
@@ -216,7 +216,7 @@ class MD5 : HashBase {
             hh[3] = hh[3] &+ D
         }
         
-        var result = Array<UInt8>()
+        var result = [UInt8]()
         result.reserveCapacity(hh.count / 4)
         
         hh.forEach {

--- a/Haneke/CryptoSwiftMD5.swift
+++ b/Haneke/CryptoSwiftMD5.swift
@@ -24,28 +24,28 @@ Permission is granted to anyone to use this software for any purpose,including c
 import Foundation
 
 /** array of bytes, little-endian representation */
-func arrayOfBytes<T>(value:T, length:Int? = nil) -> [UInt8] {
-    let totalBytes = length ?? (sizeofValue(value) * 8)
+func arrayOfBytes<T>(value:T, length:Int? = nil) -> Array<UInt8> {
+    let totalBytes = length ?? MemoryLayout<T>.size
     
-    let valuePointer = UnsafeMutablePointer<T>.alloc(1)
-    valuePointer.memory = value
+    let valuePointer = UnsafeMutablePointer<T>.allocate(capacity: 1)
+    valuePointer.pointee = value
     
-    let bytesPointer = UnsafeMutablePointer<UInt8>(valuePointer)
-    var bytes = [UInt8](count: totalBytes, repeatedValue: 0)
-    for j in 0..<min(sizeof(T),totalBytes) {
-        bytes[totalBytes - 1 - j] = (bytesPointer + j).memory
+    let bytesPointer = UnsafeMutablePointer<UInt8>(OpaquePointer(valuePointer))
+    var bytes = Array<UInt8>(repeating: 0, count: totalBytes)
+    for j in 0..<min(MemoryLayout<T>.size,totalBytes) {
+        bytes[totalBytes - 1 - j] = (bytesPointer + j).pointee
     }
     
-    valuePointer.destroy()
-    valuePointer.dealloc(1)
+    valuePointer.deinitialize()
+    valuePointer.deallocate(capacity: 1)
     
     return bytes
 }
 
 extension Int {
     /** Array of bytes with optional padding (little-endian) */
-    public func bytes(totalBytes: Int = sizeof(Int)) -> [UInt8] {
-        return arrayOfBytes(self, length: totalBytes)
+    public func bytes(totalBytes: Int = MemoryLayout<Int>.size) -> [UInt8] {
+        return arrayOfBytes(value: self, length: totalBytes)
     }
     
 }
@@ -54,36 +54,52 @@ extension NSMutableData {
     
     /** Convenient way to append bytes */
     internal func appendBytes(arrayOfBytes: [UInt8]) {
-        self.appendBytes(arrayOfBytes, length: arrayOfBytes.count)
+        self.append(arrayOfBytes, length: arrayOfBytes.count)
     }
     
 }
 
+struct BytesSequence: Sequence {
+    let chunkSize: Int
+    let data: Array<UInt8>
+    
+    func makeIterator() -> AnyIterator<ArraySlice<UInt8>> {
+        var offset:Int = 0
+        return AnyIterator {
+            let end = Swift.min(self.chunkSize, self.data.count - offset)
+            let result = self.data[offset..<offset + end]
+            offset += result.count
+            return !result.isEmpty ? result : nil
+        }
+    }
+}
+
 class HashBase {
     
-    var message: NSData
+    static let size:Int = 16 // 128 / 8
+    let message: Array<UInt8>
     
-    init(_ message: NSData) {
+    init (_ message: Array<UInt8>) {
         self.message = message
     }
     
     /** Common part for hash calculation. Prepare header data. */
-    func prepare(len: Int = 64) -> NSMutableData {
-        let tmpMessage: NSMutableData = NSMutableData(data: self.message)
+    func prepare(_ len:Int) -> Array<UInt8> {
+        var tmpMessage = message
         
         // Step 1. Append Padding Bits
-        tmpMessage.appendBytes([0x80]) // append one bit (UInt8 with one bit) to message
+        tmpMessage.append(0x80) // append one bit (UInt8 with one bit) to message
         
         // append "0" bit until message length in bits ≡ 448 (mod 512)
-        var msgLength = tmpMessage.length
+        var msgLength = tmpMessage.count
         var counter = 0
+        
         while msgLength % len != (len - 8) {
             counter += 1
             msgLength += 1
         }
-        let bufZeros = UnsafeMutablePointer<UInt8>(calloc(counter, sizeof(UInt8)))
-        tmpMessage.appendBytes(bufZeros, length: counter)
         
+        tmpMessage += Array<UInt8>(repeating: 0, count: counter)
         return tmpMessage
     }
 }
@@ -92,61 +108,67 @@ func rotateLeft(v: UInt32, n: UInt32) -> UInt32 {
     return ((v << n) & 0xFFFFFFFF) | (v >> (32 - n))
 }
 
+func sliceToUInt32Array(_ slice: ArraySlice<UInt8>) -> Array<UInt32> {
+    var result = Array<UInt32>()
+    result.reserveCapacity(16)
+    for idx in stride(from: slice.startIndex, to: slice.endIndex, by: MemoryLayout<UInt32>.size) {
+        let val1:UInt32 = (UInt32(slice[idx.advanced(by: 3)]) << 24)
+        let val2:UInt32 = (UInt32(slice[idx.advanced(by: 2)]) << 16)
+        let val3:UInt32 = (UInt32(slice[idx.advanced(by: 1)]) << 8)
+        let val4:UInt32 = UInt32(slice[idx])
+        let val:UInt32 = val1 | val2 | val3 | val4
+        result.append(val)
+    }
+    return result
+}
+
 class MD5 : HashBase {
     
+    
     /** specifies the per-round shift amounts */
-    private let s: [UInt32] = [7, 12, 17, 22,  7, 12, 17, 22,  7, 12, 17, 22,  7, 12, 17, 22,
-        5,  9, 14, 20,  5,  9, 14, 20,  5,  9, 14, 20,  5,  9, 14, 20,
-        4, 11, 16, 23,  4, 11, 16, 23,  4, 11, 16, 23,  4, 11, 16, 23,
-        6, 10, 15, 21,  6, 10, 15, 21,  6, 10, 15, 21,  6, 10, 15, 21]
+    private let s: Array<UInt32> = [7, 12, 17, 22,  7, 12, 17, 22,  7, 12, 17, 22,  7, 12, 17, 22,
+                                    5,  9, 14, 20,  5,  9, 14, 20,  5,  9, 14, 20,  5,  9, 14, 20,
+                                    4, 11, 16, 23,  4, 11, 16, 23,  4, 11, 16, 23,  4, 11, 16, 23,
+                                    6, 10, 15, 21,  6, 10, 15, 21,  6, 10, 15, 21,  6, 10, 15, 21]
     
     /** binary integer part of the sines of integers (Radians) */
-    private let k: [UInt32] = [0xd76aa478,0xe8c7b756,0x242070db,0xc1bdceee,
-        0xf57c0faf,0x4787c62a,0xa8304613,0xfd469501,
-        0x698098d8,0x8b44f7af,0xffff5bb1,0x895cd7be,
-        0x6b901122,0xfd987193,0xa679438e,0x49b40821,
-        0xf61e2562,0xc040b340,0x265e5a51,0xe9b6c7aa,
-        0xd62f105d,0x2441453,0xd8a1e681,0xe7d3fbc8,
-        0x21e1cde6,0xc33707d6,0xf4d50d87,0x455a14ed,
-        0xa9e3e905,0xfcefa3f8,0x676f02d9,0x8d2a4c8a,
-        0xfffa3942,0x8771f681,0x6d9d6122,0xfde5380c,
-        0xa4beea44,0x4bdecfa9,0xf6bb4b60,0xbebfbc70,
-        0x289b7ec6,0xeaa127fa,0xd4ef3085,0x4881d05,
-        0xd9d4d039,0xe6db99e5,0x1fa27cf8,0xc4ac5665,
-        0xf4292244,0x432aff97,0xab9423a7,0xfc93a039,
-        0x655b59c3,0x8f0ccc92,0xffeff47d,0x85845dd1,
-        0x6fa87e4f,0xfe2ce6e0,0xa3014314,0x4e0811a1,
-        0xf7537e82,0xbd3af235,0x2ad7d2bb,0xeb86d391]
+    private let k: Array<UInt32> = [0xd76aa478,0xe8c7b756,0x242070db,0xc1bdceee,
+                                    0xf57c0faf,0x4787c62a,0xa8304613,0xfd469501,
+                                    0x698098d8,0x8b44f7af,0xffff5bb1,0x895cd7be,
+                                    0x6b901122,0xfd987193,0xa679438e,0x49b40821,
+                                    0xf61e2562,0xc040b340,0x265e5a51,0xe9b6c7aa,
+                                    0xd62f105d,0x2441453,0xd8a1e681,0xe7d3fbc8,
+                                    0x21e1cde6,0xc33707d6,0xf4d50d87,0x455a14ed,
+                                    0xa9e3e905,0xfcefa3f8,0x676f02d9,0x8d2a4c8a,
+                                    0xfffa3942,0x8771f681,0x6d9d6122,0xfde5380c,
+                                    0xa4beea44,0x4bdecfa9,0xf6bb4b60,0xbebfbc70,
+                                    0x289b7ec6,0xeaa127fa,0xd4ef3085,0x4881d05,
+                                    0xd9d4d039,0xe6db99e5,0x1fa27cf8,0xc4ac5665,
+                                    0xf4292244,0x432aff97,0xab9423a7,0xfc93a039,
+                                    0x655b59c3,0x8f0ccc92,0xffeff47d,0x85845dd1,
+                                    0x6fa87e4f,0xfe2ce6e0,0xa3014314,0x4e0811a1,
+                                    0xf7537e82,0xbd3af235,0x2ad7d2bb,0xeb86d391]
     
-    private let h:[UInt32] = [0x67452301, 0xefcdab89, 0x98badcfe, 0x10325476]
+    private let h:Array<UInt32> = [0x67452301, 0xefcdab89, 0x98badcfe, 0x10325476]
     
-    func calculate() -> NSData {
-        let tmpMessage = prepare()
+    func calculate() -> Array<UInt8> {
+        var tmpMessage = prepare(64)
+        tmpMessage.reserveCapacity(tmpMessage.count + 4)
         
-        // hash values
+        // initialize hh with hash values
         var hh = h
         
         // Step 2. Append Length a 64-bit representation of lengthInBits
-        let lengthInBits = (message.length * 8)
-        let lengthBytes = lengthInBits.bytes(64 / 8)
-        tmpMessage.appendBytes(lengthBytes.reverse())
+        let lengthInBits = (message.count * 8)
+        let lengthBytes = lengthInBits.bytes(totalBytes: 64 / 8)
+        tmpMessage += lengthBytes.reversed()
         
         // Process the message in successive 512-bit chunks:
         let chunkSizeBytes = 512 / 8 // 64
-        var leftMessageBytes = tmpMessage.length
-        var i = 0
-        while i < tmpMessage.length {
-            defer {
-                i = i + chunkSizeBytes
-                leftMessageBytes -= chunkSizeBytes
-            }
-
-            let chunk = tmpMessage.subdataWithRange(NSRange(location: i, length: min(chunkSizeBytes,leftMessageBytes)))
-            
+        for chunk in BytesSequence(chunkSize: chunkSizeBytes, data: tmpMessage) {
             // break chunk into sixteen 32-bit words M[j], 0 ≤ j ≤ 15
-            var M:[UInt32] = [UInt32](count: 16, repeatedValue: 0)
-            let range = NSRange(location:0, length: M.count * sizeof(UInt32))
-            chunk.getBytes(UnsafeMutablePointer<Void>(M), range: range)
+            var M = sliceToUInt32Array(chunk)
+            assert(M.count == 16, "Invalid array")
             
             // Initialize hash value for this chunk:
             var A:UInt32 = hh[0]
@@ -184,7 +206,7 @@ class MD5 : HashBase {
                 dTemp = D
                 D = C
                 C = B
-                B = B &+ rotateLeft((A &+ F &+ k[j] &+ M[g]), n: s[j])
+                B = B &+ rotateLeft(v: A &+ F &+ k[j] &+ M[g], n: s[j])
                 A = dTemp
             }
             
@@ -194,12 +216,14 @@ class MD5 : HashBase {
             hh[3] = hh[3] &+ D
         }
         
-        let buf: NSMutableData = NSMutableData()
-        hh.forEach({ (item) -> () in
-            var i:UInt32 = item.littleEndian
-            buf.appendBytes(&i, length: sizeofValue(i))
-        })
+        var result = Array<UInt8>()
+        result.reserveCapacity(hh.count / 4)
         
-        return buf.copy() as! NSData
+        hh.forEach {
+            let itemLE = $0.littleEndian
+            result += [UInt8(itemLE & 0xff), UInt8((itemLE >> 8) & 0xff), UInt8((itemLE >> 16) & 0xff), UInt8((itemLE >> 24) & 0xff)]
+        }
+        
+        return result
     }
 }

--- a/Haneke/Data.swift
+++ b/Haneke/Data.swift
@@ -12,12 +12,12 @@ import UIKit
 public protocol DataConvertible {
     associatedtype Result
     
-    static func convertFromData(data:NSData) -> Result?
+    static func convertFromData(_ data:Data) -> Result?
 }
 
 public protocol DataRepresentable {
     
-    func asData() -> NSData!
+    func asData() -> Data!
 }
 
 private let imageSync = NSLock()
@@ -27,23 +27,23 @@ extension UIImage : DataConvertible, DataRepresentable {
     public typealias Result = UIImage
 
     // HACK: UIImage data initializer is no longer thread safe. See: https://github.com/AFNetworking/AFNetworking/issues/2572#issuecomment-115854482
-    static func safeImageWithData(data:NSData) -> Result? {
+    static func safeImageWithData(_ data:Data) -> Result? {
         imageSync.lock()
         let image = UIImage(data:data, scale: scale)
         imageSync.unlock()
         return image
     }
     
-    public class func convertFromData(data: NSData) -> Result? {
+    public class func convertFromData(_ data: Data) -> Result? {
         let image = UIImage.safeImageWithData(data)
         return image
     }
     
-    public func asData() -> NSData! {
-        return self.hnk_data()
+    public func asData() -> Data! {
+        return self.hnk_data() as Data!
     }
     
-    private static let scale = UIScreen.mainScreen().scale
+    fileprivate static let scale = UIScreen.main.scale
     
 }
 
@@ -51,26 +51,26 @@ extension String : DataConvertible, DataRepresentable {
     
     public typealias Result = String
     
-    public static func convertFromData(data: NSData) -> Result? {
-        let string = NSString(data: data, encoding: NSUTF8StringEncoding)
+    public static func convertFromData(_ data: Data) -> Result? {
+        let string = NSString(data: data, encoding: String.Encoding.utf8.rawValue)
         return string as? Result
     }
     
-    public func asData() -> NSData! {
-        return self.dataUsingEncoding(NSUTF8StringEncoding)
+    public func asData() -> Data! {
+        return self.data(using: String.Encoding.utf8)
     }
     
 }
 
-extension NSData : DataConvertible, DataRepresentable {
+extension Data : DataConvertible, DataRepresentable {
     
-    public typealias Result = NSData
+    public typealias Result = Data
     
-    public class func convertFromData(data: NSData) -> Result? {
+    public static func convertFromData(_ data: Data) -> Result? {
         return data
     }
     
-    public func asData() -> NSData! {
+    public func asData() -> Data! {
         return self
     }
     
@@ -82,9 +82,9 @@ public enum JSON : DataConvertible, DataRepresentable {
     case Dictionary([String:AnyObject])
     case Array([AnyObject])
     
-    public static func convertFromData(data: NSData) -> Result? {
+    public static func convertFromData(_ data: Data) -> Result? {
         do {
-            let object : AnyObject = try NSJSONSerialization.JSONObjectWithData(data, options: NSJSONReadingOptions())
+            let object : Any = try JSONSerialization.jsonObject(with: data, options: JSONSerialization.ReadingOptions())
             switch (object) {
             case let dictionary as [String:AnyObject]:
                 return JSON.Dictionary(dictionary)
@@ -94,17 +94,17 @@ public enum JSON : DataConvertible, DataRepresentable {
                 return nil
             }
         } catch {
-            Log.error("Invalid JSON data", error as NSError)
+            Log.error(message: "Invalid JSON data", error: error)
             return nil
         }
     }
     
-    public func asData() -> NSData! {
+    public func asData() -> Data! {
         switch (self) {
         case .Dictionary(let dictionary):
-            return try? NSJSONSerialization.dataWithJSONObject(dictionary, options: NSJSONWritingOptions())
+            return try? JSONSerialization.data(withJSONObject: dictionary, options: JSONSerialization.WritingOptions())
         case .Array(let array):
-            return try? NSJSONSerialization.dataWithJSONObject(array, options: NSJSONWritingOptions())
+            return try? JSONSerialization.data(withJSONObject: array, options: JSONSerialization.WritingOptions())
         }
     }
     

--- a/Haneke/DiskCache.swift
+++ b/Haneke/DiskCache.swift
@@ -8,228 +8,230 @@
 
 import Foundation
 
-public class DiskCache {
+open class DiskCache {
     
-    public class func basePath() -> String {
-        let cachesPath = NSSearchPathForDirectoriesInDomains(NSSearchPathDirectory.CachesDirectory, NSSearchPathDomainMask.UserDomainMask, true)[0]
+    open class func basePath() -> String {
+        let cachesPath = NSSearchPathForDirectoriesInDomains(FileManager.SearchPathDirectory.cachesDirectory, FileManager.SearchPathDomainMask.userDomainMask, true)[0]
         let hanekePathComponent = HanekeGlobals.Domain
-        let basePath = (cachesPath as NSString).stringByAppendingPathComponent(hanekePathComponent)
+        let basePath = (cachesPath as NSString).appendingPathComponent(hanekePathComponent)
         // TODO: Do not recaculate basePath value
         return basePath
     }
     
-    public let path: String
+    open let path: String
 
-    public var size : UInt64 = 0
+    open var size : UInt64 = 0
 
-    public var capacity : UInt64 = 0 {
+    open var capacity : UInt64 = 0 {
         didSet {
-            dispatch_async(self.cacheQueue, {
+            self.cacheQueue.async(execute: {
                 self.controlCapacity()
             })
         }
     }
 
-    public lazy var cacheQueue : dispatch_queue_t = {
+    open lazy var cacheQueue : DispatchQueue = {
         let queueName = HanekeGlobals.Domain + "." + (self.path as NSString).lastPathComponent
-        let cacheQueue = dispatch_queue_create(queueName, nil)
+        let cacheQueue = DispatchQueue(label: queueName, attributes: [])
         return cacheQueue
     }()
     
     public init(path: String, capacity: UInt64 = UINT64_MAX) {
         self.path = path
         self.capacity = capacity
-        dispatch_async(self.cacheQueue, {
+        self.cacheQueue.async(execute: {
             self.calculateSize()
             self.controlCapacity()
         })
     }
     
-    public func setData(@autoclosure(escaping) getData: () -> NSData?, key: String) {
-        dispatch_async(cacheQueue, {
+    open func setData( _ getData: @autoclosure @escaping () -> Data?, key: String) {
+        cacheQueue.async(execute: {
             if let data = getData() {
                 self.setDataSync(data, key: key)
             } else {
-                Log.error("Failed to get data for key \(key)")
+                Log.error(message: "Failed to get data for key \(key)")
             }
         })
     }
     
-    public func fetchData(key key: String, failure fail: ((NSError?) -> ())? = nil, success succeed: (NSData) -> ()) {
-        dispatch_async(cacheQueue) {
-            let path = self.pathForKey(key)
+    open func fetchData(key: String, failure fail: ((Error?) -> ())? = nil, success succeed: @escaping (Data) -> ()) {
+        cacheQueue.async {
+            let path = self.path(forKey: key)
             do {
-                let data = try NSData(contentsOfFile: path, options: NSDataReadingOptions())
-                dispatch_async(dispatch_get_main_queue()) {
+                let data = try Data(contentsOf: URL(fileURLWithPath: path), options: Data.ReadingOptions())
+                DispatchQueue.main.async {
                     succeed(data)
                 }
-                self.updateDiskAccessDateAtPath(path)
+                self.updateDiskAccessDate(atPath: path)
             } catch {
                 if let block = fail {
-                    dispatch_async(dispatch_get_main_queue()) {
-                        block(error as NSError)
+                    DispatchQueue.main.async {
+                        block(error)
                     }
                 }
             }
         }
     }
 
-    public func removeData(key: String) {
-        dispatch_async(cacheQueue, {
-            let path = self.pathForKey(key)
-            self.removeFileAtPath(path)
+    open func removeData(with key: String) {
+        cacheQueue.async(execute: {
+            let path = self.path(forKey: key)
+            self.removeFile(atPath: path)
         })
     }
     
-    public func removeAllData(completion: (() -> ())? = nil) {
-        let fileManager = NSFileManager.defaultManager()
+    open func removeAllData(_ completion: (() -> ())? = nil) {
+        let fileManager = FileManager.default
         let cachePath = self.path
-        dispatch_async(cacheQueue, {
+        cacheQueue.async(execute: {
             do {
-                let contents = try fileManager.contentsOfDirectoryAtPath(cachePath)
+                let contents = try fileManager.contentsOfDirectory(atPath: cachePath)
                 for pathComponent in contents {
-                    let path = (cachePath as NSString).stringByAppendingPathComponent(pathComponent)
+                    let path = (cachePath as NSString).appendingPathComponent(pathComponent)
                     do {
-                        try fileManager.removeItemAtPath(path)
+                        try fileManager.removeItem(atPath: path)
                     } catch {
-                        Log.error("Failed to remove path \(path)", error as NSError)
+                        Log.error(message: "Failed to remove path \(path)", error: error)
                     }
                 }
                 self.calculateSize()
             } catch {
-                Log.error("Failed to list directory", error as NSError)
+                Log.error(message: "Failed to list directory", error: error)
             }
             if let completion = completion {
-                dispatch_async(dispatch_get_main_queue()) {
+                DispatchQueue.main.async {
                     completion()
                 }
             }
         })
     }
 
-    public func updateAccessDate(@autoclosure(escaping) getData: () -> NSData?, key: String) {
-        dispatch_async(cacheQueue, {
-            let path = self.pathForKey(key)
-            let fileManager = NSFileManager.defaultManager()
-            if (!(fileManager.fileExistsAtPath(path) && self.updateDiskAccessDateAtPath(path))){
+    open func updateAccessDate( _ getData: @autoclosure @escaping () -> Data?, key: String) {
+        cacheQueue.async(execute: {
+            let path = self.path(forKey: key)
+            let fileManager = FileManager.default
+            if (!(fileManager.fileExists(atPath: path) && self.updateDiskAccessDate(atPath: path))){
                 if let data = getData() {
                     self.setDataSync(data, key: key)
                 } else {
-                    Log.error("Failed to get data for key \(key)")
+                    Log.error(message: "Failed to get data for key \(key)")
                 }
             }
         })
     }
 
-    public func pathForKey(key: String) -> String {
+    open func path(forKey key: String) -> String {
         let escapedFilename = key.escapedFilename()
         let filename = escapedFilename.characters.count < Int(NAME_MAX) ? escapedFilename : key.MD5Filename()
-        let keyPath = (self.path as NSString).stringByAppendingPathComponent(filename)
+        let keyPath = (self.path as NSString).appendingPathComponent(filename)
         return keyPath
     }
     
     // MARK: Private
     
-    private func calculateSize() {
-        let fileManager = NSFileManager.defaultManager()
+    fileprivate func calculateSize() {
+        let fileManager = FileManager.default
         size = 0
         let cachePath = self.path
         do {
-            let contents = try fileManager.contentsOfDirectoryAtPath(cachePath)
+            let contents = try fileManager.contentsOfDirectory(atPath: cachePath)
             for pathComponent in contents {
-                let path = (cachePath as NSString).stringByAppendingPathComponent(pathComponent)
+                let path = (cachePath as NSString).appendingPathComponent(pathComponent)
                 do {
-                    let attributes : NSDictionary = try fileManager.attributesOfItemAtPath(path)
-                    size += attributes.fileSize()
+                    let attributes: [FileAttributeKey: Any] = try fileManager.attributesOfItem(atPath: path)
+                    if let fileSize = attributes[FileAttributeKey.size] as? UInt64 {
+                        size += fileSize
+                    }
                 } catch {
-                    Log.error("Failed to read file size of \(path)", error as NSError)
+                    Log.error(message: "Failed to list directory", error: error)
                 }
             }
-
+            
         } catch {
-            Log.error("Failed to list directory", error as NSError)
+            Log.error(message: "Failed to list directory", error: error)
         }
     }
     
-    private func controlCapacity() {
+    fileprivate func controlCapacity() {
         if self.size <= self.capacity { return }
         
-        let fileManager = NSFileManager.defaultManager()
+        let fileManager = FileManager.default
         let cachePath = self.path
-        fileManager.enumerateContentsOfDirectoryAtPath(cachePath, orderedByProperty: NSURLContentModificationDateKey, ascending: true) { (URL : NSURL, _, inout stop : Bool) -> Void in
+        fileManager.enumerateContentsOfDirectory(atPath: cachePath, orderedByProperty: URLResourceKey.contentModificationDateKey.rawValue, ascending: true) { (URL : URL, _, stop : inout Bool) -> Void in
             
-            if let path = URL.path {
-                self.removeFileAtPath(path)
+            self.removeFile(atPath: URL.path)
 
-                stop = self.size <= self.capacity
-            }
+            stop = self.size <= self.capacity
         }
     }
     
-    private func setDataSync(data: NSData, key: String) {
-        let path = self.pathForKey(key)
-        let fileManager = NSFileManager.defaultManager()
-        let previousAttributes : NSDictionary? = try? fileManager.attributesOfItemAtPath(path)
+    fileprivate func setDataSync(_ data: Data, key: String) {
+        let path = self.path(forKey: key)
+        let fileManager = FileManager.default
+        let previousAttributes : [FileAttributeKey: Any]? = try? fileManager.attributesOfItem(atPath: path)
         
         do {
-            try data.writeToFile(path, options: NSDataWritingOptions.AtomicWrite)
+            try data.write(to: URL(fileURLWithPath: path), options: Data.WritingOptions.atomicWrite)
         } catch {
-            Log.error("Failed to write key \(key)", error as NSError)
+            Log.error(message: "Failed to write key \(key)", error: error)
         }
         
         if let attributes = previousAttributes {
-            substractSize(attributes.fileSize())
+            if let fileSize = attributes[FileAttributeKey.size] as? UInt64 {
+                substract(size: fileSize)
+            }
         }
-        self.size += UInt64(data.length)
+        self.size += UInt64(data.count)
         self.controlCapacity()
     }
     
-    private func updateDiskAccessDateAtPath(path: String) -> Bool {
-        let fileManager = NSFileManager.defaultManager()
-        let now = NSDate()
+    fileprivate func updateDiskAccessDate(atPath path: String) -> Bool {
+        let fileManager = FileManager.default
+        let now = Date()
         do {
-            try fileManager.setAttributes([NSFileModificationDate : now], ofItemAtPath: path)
+            try fileManager.setAttributes([FileAttributeKey.modificationDate : now], ofItemAtPath: path)
             return true
         } catch {
-            Log.error("Failed to update access date", error as NSError)
+            Log.error(message: "Failed to update access date", error: error)
             return false
         }
     }
     
-    private func removeFileAtPath(path: String) {
-        let fileManager = NSFileManager.defaultManager()
+    fileprivate func removeFile(atPath path: String) {
+        let fileManager = FileManager.default
         do {
-            let attributes : NSDictionary =  try fileManager.attributesOfItemAtPath(path)
-            let fileSize = attributes.fileSize()
+            let attributes: [FileAttributeKey: Any] = try fileManager.attributesOfItem(atPath: path)
             do {
-                try fileManager.removeItemAtPath(path)
-                substractSize(fileSize)
+                try fileManager.removeItem(atPath: path)
+                if let fileSize = attributes[FileAttributeKey.size] as? UInt64 {
+                    substract(size: fileSize)
+                }
             } catch {
-                Log.error("Failed to remove file", error as NSError)
+                Log.error(message: "Failed to remove file", error: error)
             }
         } catch {
-            let castedError = error as NSError
-            if isNoSuchFileError(castedError) {
-                Log.debug("File not found", castedError)
+            if isNoSuchFileError(error) {
+                Log.debug(message: "File not found", error: error)
             } else {
-                Log.error("Failed to remove file", castedError)
+                Log.error(message: "Failed to remove file", error: error)
             }
         }
     }
 
-    private func substractSize(size : UInt64) {
+    fileprivate func substract(size : UInt64) {
         if (self.size >= size) {
             self.size -= size
         } else {
-            Log.error("Disk cache size (\(self.size)) is smaller than size to substract (\(size))")
+            Log.error(message: "Disk cache size (\(self.size)) is smaller than size to substract (\(size))")
             self.size = 0
         }
     }
 }
 
-private func isNoSuchFileError(error : NSError?) -> Bool {
+private func isNoSuchFileError(_ error : Error?) -> Bool {
     if let error = error {
-        return NSCocoaErrorDomain == error.domain && error.code == NSFileReadNoSuchFileError
+        return NSCocoaErrorDomain == (error as NSError).domain && (error as NSError).code == NSFileReadNoSuchFileError
     }
     return false
 }

--- a/Haneke/DiskFetcher.swift
+++ b/Haneke/DiskFetcher.swift
@@ -35,7 +35,7 @@ open class DiskFetcher<T : DataConvertible> : Fetcher<T> {
     // MARK: Fetcher
     
     
-    open override func fetch(failure fail: ((Error?) -> ()), success succeed: @escaping (T.Result) -> ()) {
+    open override func fetch(failure fail: @escaping ((Error?) -> ()), success succeed: @escaping (T.Result) -> ()) {
         self.cancelled = false
         DispatchQueue.global(qos: DispatchQoS.QoSClass.default).async(execute: { [weak self] in
             if let strongSelf = self {
@@ -50,7 +50,7 @@ open class DiskFetcher<T : DataConvertible> : Fetcher<T> {
     
     // MARK: Private
     
-    fileprivate func privateFetch(failure fail: ((Error?) -> ()), success succeed: @escaping (T.Result) -> ()) {
+    fileprivate func privateFetch(failure fail: @escaping ((Error?) -> ()), success succeed: @escaping (T.Result) -> ()) {
         if self.cancelled {
             return
         }

--- a/Haneke/DiskFetcher.swift
+++ b/Haneke/DiskFetcher.swift
@@ -14,14 +14,14 @@ extension HanekeGlobals {
     public struct DiskFetcher {
         
         public enum ErrorCode : Int {
-            case InvalidData = -500
+            case invalidData = -500
         }
         
     }
     
 }
 
-public class DiskFetcher<T : DataConvertible> : Fetcher<T> {
+open class DiskFetcher<T : DataConvertible> : Fetcher<T> {
     
     let path: String
     var cancelled = false
@@ -34,35 +34,36 @@ public class DiskFetcher<T : DataConvertible> : Fetcher<T> {
     
     // MARK: Fetcher
     
-    public override func fetch(failure fail: ((NSError?) -> ()), success succeed: (T.Result) -> ()) {
+    
+    open override func fetch(failure fail: ((Error?) -> ()), success succeed: @escaping (T.Result) -> ()) {
         self.cancelled = false
-        dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), { [weak self] in
+        DispatchQueue.global(qos: DispatchQoS.QoSClass.default).async(execute: { [weak self] in
             if let strongSelf = self {
                 strongSelf.privateFetch(failure: fail, success: succeed)
             }
         })
     }
     
-    public override func cancelFetch() {
+    open override func cancelFetch() {
         self.cancelled = true
     }
     
     // MARK: Private
     
-    private func privateFetch(failure fail: ((NSError?) -> ()), success succeed: (T.Result) -> ()) {
+    fileprivate func privateFetch(failure fail: ((Error?) -> ()), success succeed: @escaping (T.Result) -> ()) {
         if self.cancelled {
             return
         }
         
-        let data : NSData
+        let data : Data
         do {
-            data = try NSData(contentsOfFile: self.path, options: NSDataReadingOptions())
+            data = try Data(contentsOf: URL(fileURLWithPath: self.path), options: Data.ReadingOptions())
         } catch {
-            dispatch_async(dispatch_get_main_queue()) {
+            DispatchQueue.main.async {
                 if self.cancelled {
                     return
                 }
-                fail(error as NSError)
+                fail(error)
             }
             return
         }
@@ -74,14 +75,14 @@ public class DiskFetcher<T : DataConvertible> : Fetcher<T> {
         guard let value : T.Result = T.convertFromData(data) else {
             let localizedFormat = NSLocalizedString("Failed to convert value from data at path %@", comment: "Error description")
             let description = String(format:localizedFormat, self.path)
-            let error = errorWithCode(HanekeGlobals.DiskFetcher.ErrorCode.InvalidData.rawValue, description: description)
-            dispatch_async(dispatch_get_main_queue()) {
+            let error = errorWithCode(HanekeGlobals.DiskFetcher.ErrorCode.invalidData.rawValue, description: description)
+            DispatchQueue.main.async {
                 fail(error)
             }
             return
         }
         
-        dispatch_async(dispatch_get_main_queue(), {
+        DispatchQueue.main.async(execute: {
             if self.cancelled {
                 return
             }

--- a/Haneke/Fetch.swift
+++ b/Haneke/Fetch.swift
@@ -31,7 +31,7 @@ open class Fetch<T> {
     
     public init() {}
     
-    open func onSuccess(_ onSuccess: Succeeder) -> Self {
+    open func onSuccess(_ onSuccess: @escaping Succeeder) -> Self {
         self.onSuccess = onSuccess
         switch self.state {
         case FetchState.success(let wrapper):
@@ -42,7 +42,7 @@ open class Fetch<T> {
         return self
     }
     
-    open func onFailure(_ onFailure: Failer) -> Self {
+    open func onFailure(_ onFailure: @escaping Failer) -> Self {
         self.onFailure = onFailure
         switch self.state {
         case FetchState.failure(let error):

--- a/Haneke/Fetch.swift
+++ b/Haneke/Fetch.swift
@@ -9,32 +9,32 @@
 import Foundation
 
 enum FetchState<T> {
-    case Pending
+    case pending
     // Using Wrapper as a workaround for error 'unimplemented IR generation feature non-fixed multi-payload enum layout'
     // See: http://swiftradar.tumblr.com/post/88314603360/swift-fails-to-compile-enum-with-two-data-cases
     // See: http://owensd.io/2014/08/06/fixed-enum-layout.html
-    case Success(Wrapper<T>)
-    case Failure(NSError?)
+    case success(Wrapper<T>)
+    case failure(Error?)
 }
 
-public class Fetch<T> {
+open class Fetch<T> {
     
     public typealias Succeeder = (T) -> ()
     
-    public typealias Failer = (NSError?) -> ()
+    public typealias Failer = (Error?) -> ()
     
-    private var onSuccess : Succeeder?
+    fileprivate var onSuccess : Succeeder?
     
-    private var onFailure : Failer?
+    fileprivate var onFailure : Failer?
     
-    private var state : FetchState<T> = FetchState.Pending
+    fileprivate var state : FetchState<T> = FetchState.pending
     
     public init() {}
     
-    public func onSuccess(onSuccess: Succeeder) -> Self {
+    open func onSuccess(_ onSuccess: Succeeder) -> Self {
         self.onSuccess = onSuccess
         switch self.state {
-        case FetchState.Success(let wrapper):
+        case FetchState.success(let wrapper):
             onSuccess(wrapper.value)
         default:
             break
@@ -42,10 +42,10 @@ public class Fetch<T> {
         return self
     }
     
-    public func onFailure(onFailure: Failer) -> Self {
+    open func onFailure(_ onFailure: Failer) -> Self {
         self.onFailure = onFailure
         switch self.state {
-        case FetchState.Failure(let error):
+        case FetchState.failure(let error):
             onFailure(error)
         default:
             break
@@ -53,19 +53,19 @@ public class Fetch<T> {
         return self
     }
     
-    func succeed(value: T) {
-        self.state = FetchState.Success(Wrapper(value))
+    func succeed(_ value: T) {
+        self.state = FetchState.success(Wrapper(value))
         self.onSuccess?(value)
     }
     
-    func fail(error: NSError? = nil) {
-        self.state = FetchState.Failure(error)
+    func fail(_ error: Error? = nil) {
+        self.state = FetchState.failure(error)
         self.onFailure?(error)
     }
     
     var hasFailed : Bool {
         switch self.state {
-        case FetchState.Failure(_):
+        case FetchState.failure(_):
             return true
         default:
             return false
@@ -74,7 +74,7 @@ public class Fetch<T> {
     
     var hasSucceeded : Bool {
         switch self.state {
-        case FetchState.Success(_):
+        case FetchState.success(_):
             return true
         default:
             return false
@@ -83,7 +83,7 @@ public class Fetch<T> {
     
 }
 
-public class Wrapper<T> {
-    public let value: T
+open class Wrapper<T> {
+    open let value: T
     public init(_ value: T) { self.value = value }
 }

--- a/Haneke/Fetcher.swift
+++ b/Haneke/Fetcher.swift
@@ -17,7 +17,7 @@ open class Fetcher<T : DataConvertible> {
         self.key = key
     }
     
-    open func fetch(failure fail: ((Error?) -> ()), success succeed: @escaping (T.Result) -> ()) {}
+    open func fetch(failure fail: @escaping ((Error?) -> ()), success succeed: @escaping (T.Result) -> ()) {}
     
     open func cancelFetch() {}
 }
@@ -31,7 +31,7 @@ class SimpleFetcher<T : DataConvertible> : Fetcher<T> {
         super.init(key: key)
     }
     
-    override func fetch(failure fail: ((Error?) -> ()), success succeed: @escaping (T.Result) -> ()) {
+    override func fetch(failure fail: @escaping ((Error?) -> ()), success succeed: @escaping (T.Result) -> ()) {
         let value = getValue()
         succeed(value)
     }

--- a/Haneke/Fetcher.swift
+++ b/Haneke/Fetcher.swift
@@ -9,29 +9,29 @@
 import UIKit
 
 // See: http://stackoverflow.com/questions/25915306/generic-closure-in-protocol
-public class Fetcher<T : DataConvertible> {
+open class Fetcher<T : DataConvertible> {
 
-    public let key: String
+    open let key: String
     
     public init(key: String) {
         self.key = key
     }
     
-    public func fetch(failure fail: ((NSError?) -> ()), success succeed: (T.Result) -> ()) {}
+    open func fetch(failure fail: ((Error?) -> ()), success succeed: @escaping (T.Result) -> ()) {}
     
-    public func cancelFetch() {}
+    open func cancelFetch() {}
 }
 
 class SimpleFetcher<T : DataConvertible> : Fetcher<T> {
     
     let getValue : () -> T.Result
     
-    init(key: String, @autoclosure(escaping) value getValue : () -> T.Result) {
+    init(key: String, value getValue : @autoclosure @escaping () -> T.Result) {
         self.getValue = getValue
         super.init(key: key)
     }
     
-    override func fetch(failure fail: ((NSError?) -> ()), success succeed: (T.Result) -> ()) {
+    override func fetch(failure fail: ((Error?) -> ()), success succeed: @escaping (T.Result) -> ()) {
         let value = getValue()
         succeed(value)
     }

--- a/Haneke/Format.swift
+++ b/Haneke/Format.swift
@@ -16,7 +16,7 @@ public struct Format<T> {
     
     public var transform : ((T) -> (T))?
     
-    public var convertToData : (T -> NSData)?
+    public var convertToData : ((T) -> Data)?
 
     public init(name: String, diskCapacity : UInt64 = UINT64_MAX, transform: ((T) -> (T))? = nil) {
         self.name = name
@@ -24,7 +24,7 @@ public struct Format<T> {
         self.transform = transform
     }
     
-    public func apply(value : T) -> T {
+    public func apply(_ value : T) -> T {
         var transformed = value
         if let transform = self.transform {
             transformed = transform(value)
@@ -54,14 +54,14 @@ public struct ImageResizer {
     
     public let compressionQuality : Float
     
-    public init(size: CGSize = CGSizeZero, scaleMode: ScaleMode = .None, allowUpscaling: Bool = true, compressionQuality: Float = 1.0) {
+    public init(size: CGSize = CGSize.zero, scaleMode: ScaleMode = .None, allowUpscaling: Bool = true, compressionQuality: Float = 1.0) {
         self.size = size
         self.scaleMode = scaleMode
         self.allowUpscaling = allowUpscaling
         self.compressionQuality = compressionQuality
     }
     
-    public func resizeImage(image: UIImage) -> UIImage {
+    public func resizeImage(_ image: UIImage) -> UIImage {
         var resizeToSize: CGSize
         switch self.scaleMode {
         case .Fill:
@@ -87,7 +87,7 @@ public struct ImageResizer {
             return image
         }
         
-        let resizedImage = image.hnk_imageByScalingToSize(resizeToSize)
+        let resizedImage = image.hnk_imageByScaling(toSize: resizeToSize)
         return resizedImage
     }
 }

--- a/Haneke/Haneke.swift
+++ b/Haneke/Haneke.swift
@@ -16,40 +16,40 @@ public struct HanekeGlobals {
 
 public struct Shared {
     
-    public static var imageCache : Cache<UIImage> {
+    public static var imageCache : HanekeCache<UIImage> {
         struct Static {
             static let name = "shared-images"
-            static let cache = Cache<UIImage>(name: name)
+            static let cache = HanekeCache<UIImage>(name: name)
         }
         return Static.cache
     }
     
-    public static var dataCache : Cache<NSData> {
+    public static var dataCache : HanekeCache<Data> {
         struct Static {
             static let name = "shared-data"
-            static let cache = Cache<NSData>(name: name)
+            static let cache = HanekeCache<Data>(name: name)
         }
         return Static.cache
     }
     
-    public static var stringCache : Cache<String> {
+    public static var stringCache : HanekeCache<String> {
         struct Static {
             static let name = "shared-strings"
-            static let cache = Cache<String>(name: name)
+            static let cache = HanekeCache<String>(name: name)
         }
         return Static.cache
     }
     
-    public static var JSONCache : Cache<JSON> {
+    public static var JSONCache : HanekeCache<JSON> {
         struct Static {
             static let name = "shared-json"
-            static let cache = Cache<JSON>(name: name)
+            static let cache = HanekeCache<JSON>(name: name)
         }
         return Static.cache
     }
 }
 
-func errorWithCode(code: Int, description: String) -> NSError {
+func errorWithCode(_ code: Int, description: String) -> Error {
     let userInfo = [NSLocalizedDescriptionKey: description]
-    return NSError(domain: HanekeGlobals.Domain, code: code, userInfo: userInfo)
+    return NSError(domain: HanekeGlobals.Domain, code: code, userInfo: userInfo) as Error
 }

--- a/Haneke/Haneke.swift
+++ b/Haneke/Haneke.swift
@@ -16,34 +16,34 @@ public struct HanekeGlobals {
 
 public struct Shared {
     
-    public static var imageCache : HanekeCache<UIImage> {
+    public static var imageCache : Cache<UIImage> {
         struct Static {
             static let name = "shared-images"
-            static let cache = HanekeCache<UIImage>(name: name)
+            static let cache = Cache<UIImage>(name: name)
         }
         return Static.cache
     }
     
-    public static var dataCache : HanekeCache<Data> {
+    public static var dataCache : Cache<Data> {
         struct Static {
             static let name = "shared-data"
-            static let cache = HanekeCache<Data>(name: name)
+            static let cache = Cache<Data>(name: name)
         }
         return Static.cache
     }
     
-    public static var stringCache : HanekeCache<String> {
+    public static var stringCache : Cache<String> {
         struct Static {
             static let name = "shared-strings"
-            static let cache = HanekeCache<String>(name: name)
+            static let cache = Cache<String>(name: name)
         }
         return Static.cache
     }
     
-    public static var JSONCache : HanekeCache<JSON> {
+    public static var JSONCache : Cache<JSON> {
         struct Static {
             static let name = "shared-json"
-            static let cache = HanekeCache<JSON>(name: name)
+            static let cache = Cache<JSON>(name: name)
         }
         return Static.cache
     }

--- a/Haneke/HanekeCache.swift
+++ b/Haneke/HanekeCache.swift
@@ -33,6 +33,7 @@ extension HanekeGlobals {
     
 }
 
+// In order to not conflict with upcoming `Cache` naming convention for Swift3, name changed to HanekeCache
 open class HanekeCache<T: DataConvertible> where T.Result == T, T : DataRepresentable {
     
     let name: String

--- a/Haneke/HanekeCache.swift
+++ b/Haneke/HanekeCache.swift
@@ -10,10 +10,10 @@ import UIKit
 
 // Used to add T to NSCache
 class ObjectWrapper : NSObject {
-    let value: Any
+    let hnk_value: Any
     
     init(value: Any) {
-        self.value = value
+        self.hnk_value = value
     }
 }
 
@@ -25,15 +25,15 @@ extension HanekeGlobals {
         public static let OriginalFormatName = "original"
 
         public enum ErrorCode : Int {
-            case ObjectNotFound = -100
-            case FormatNotFound = -101
+            case objectNotFound = -100
+            case formatNotFound = -101
         }
         
     }
     
 }
 
-public class Cache<T: DataConvertible where T.Result == T, T : DataRepresentable> {
+open class HanekeCache<T: DataConvertible> where T.Result == T, T : DataRepresentable {
     
     let name: String
     
@@ -42,12 +42,12 @@ public class Cache<T: DataConvertible where T.Result == T, T : DataRepresentable
     public init(name: String) {
         self.name = name
         
-        let notifications = NSNotificationCenter.defaultCenter()
+        let notifications = NotificationCenter.default
         // Using block-based observer to avoid subclassing NSObject
-        memoryWarningObserver = notifications.addObserverForName(UIApplicationDidReceiveMemoryWarningNotification,
+        memoryWarningObserver = notifications.addObserver(forName: Notification.Name.UIApplicationDidReceiveMemoryWarning,
             object: nil,
-            queue: NSOperationQueue.mainQueue(),
-            usingBlock: { [unowned self] (notification : NSNotification!) -> Void in
+            queue: OperationQueue.main,
+            using: { [unowned self] (notification : Notification!) -> Void in
                 self.onMemoryWarning()
             }
         )
@@ -57,15 +57,15 @@ public class Cache<T: DataConvertible where T.Result == T, T : DataRepresentable
     }
     
     deinit {
-        let notifications = NSNotificationCenter.defaultCenter()
-        notifications.removeObserver(memoryWarningObserver, name: UIApplicationDidReceiveMemoryWarningNotification, object: nil)
+        let notifications = NotificationCenter.default
+        notifications.removeObserver(memoryWarningObserver, name: Notification.Name.UIApplicationDidReceiveMemoryWarning, object: nil)
     }
     
-    public func set(value value: T, key: String, formatName: String = HanekeGlobals.Cache.OriginalFormatName, success succeed: ((T) -> ())? = nil) {
+    open func set(value: T, key: String, formatName: String = HanekeGlobals.Cache.OriginalFormatName, success succeed: ((T) -> ())? = nil) {
         if let (format, memoryCache, diskCache) = self.formats[formatName] {
             self.format(value: value, format: format) { formattedValue in
                 let wrapper = ObjectWrapper(value: formattedValue)
-                memoryCache.setObject(wrapper, forKey: key)
+                memoryCache.setObject(wrapper, forKey: key as AnyObject)
                 // Value data is sent as @autoclosure to be executed in the disk cache queue.
                 diskCache.setData(self.dataFromValue(formattedValue, format: format), key: key)
                 succeed?(formattedValue)
@@ -75,10 +75,10 @@ public class Cache<T: DataConvertible where T.Result == T, T : DataRepresentable
         }
     }
     
-    public func fetch(key key: String, formatName: String = HanekeGlobals.Cache.OriginalFormatName, failure fail : Fetch<T>.Failer? = nil, success succeed : Fetch<T>.Succeeder? = nil) -> Fetch<T> {
-        let fetch = Cache.buildFetch(failure: fail, success: succeed)
+    open func fetch(key: String, formatName: String = HanekeGlobals.Cache.OriginalFormatName, failure fail : Fetch<T>.Failer? = nil, success succeed : Fetch<T>.Succeeder? = nil) -> Fetch<T> {
+        let fetch = HanekeCache.buildFetch(failure: fail, success: succeed)
         if let (format, memoryCache, diskCache) = self.formats[formatName] {
-            if let wrapper = memoryCache.objectForKey(key) as? ObjectWrapper, let result = wrapper.value as? T {
+            if let wrapper = memoryCache.object(forKey: key as AnyObject) as? ObjectWrapper, let result = wrapper.hnk_value as? T {
                 fetch.succeed(result)
                 diskCache.updateAccessDate(self.dataFromValue(result, format: format), key: key)
                 return fetch
@@ -93,22 +93,22 @@ public class Cache<T: DataConvertible where T.Result == T, T : DataRepresentable
         } else {
             let localizedFormat = NSLocalizedString("Format %@ not found", comment: "Error description")
             let description = String(format:localizedFormat, formatName)
-            let error = errorWithCode(HanekeGlobals.Cache.ErrorCode.FormatNotFound.rawValue, description: description)
+            let error = errorWithCode(HanekeGlobals.Cache.ErrorCode.formatNotFound.rawValue, description: description)
             fetch.fail(error)
         }
         return fetch
     }
     
-    public func fetch(fetcher fetcher : Fetcher<T>, formatName: String = HanekeGlobals.Cache.OriginalFormatName, failure fail : Fetch<T>.Failer? = nil, success succeed : Fetch<T>.Succeeder? = nil) -> Fetch<T> {
+    open func fetch(fetcher : Fetcher<T>, formatName: String = HanekeGlobals.Cache.OriginalFormatName, failure fail : Fetch<T>.Failer? = nil, success succeed : Fetch<T>.Succeeder? = nil) -> Fetch<T> {
         let key = fetcher.key
-        let fetch = Cache.buildFetch(failure: fail, success: succeed)
+        let fetch = HanekeCache.buildFetch(failure: fail, success: succeed)
         self.fetch(key: key, formatName: formatName, failure: { error in
-            if error?.code == HanekeGlobals.Cache.ErrorCode.FormatNotFound.rawValue {
+            if (error as? NSError)?.code == HanekeGlobals.Cache.ErrorCode.formatNotFound.rawValue {
                 fetch.fail(error)
             }
             
             if let (format, _, _) = self.formats[formatName] {
-                self.fetchAndSet(fetcher, format: format, failure: {error in
+                self.fetchAndSet(fetcher, format: format, failure: { error in
                     fetch.fail(error)
                 }) {value in
                     fetch.succeed(value)
@@ -122,35 +122,35 @@ public class Cache<T: DataConvertible where T.Result == T, T : DataRepresentable
         return fetch
     }
 
-    public func remove(key key: String, formatName: String = HanekeGlobals.Cache.OriginalFormatName) {
+    open func remove(key: String, formatName: String = HanekeGlobals.Cache.OriginalFormatName) {
         if let (_, memoryCache, diskCache) = self.formats[formatName] {
-            memoryCache.removeObjectForKey(key)
-            diskCache.removeData(key)
+            memoryCache.removeObject(forKey: key as AnyObject)
+            diskCache.removeData(with: key)
         }
     }
     
-    public func removeAll(completion: (() -> ())? = nil) {
-        let group = dispatch_group_create();
+    open func removeAll(_ completion: (() -> ())? = nil) {
+        let group = DispatchGroup()
         for (_, (_, memoryCache, diskCache)) in self.formats {
             memoryCache.removeAllObjects()
-            dispatch_group_enter(group)
+            group.enter()
             diskCache.removeAllData {
-                dispatch_group_leave(group)
+                group.leave()
             }
         }
-        dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)) {
-            let timeout = dispatch_time(DISPATCH_TIME_NOW, Int64(60 * NSEC_PER_SEC))
-            if dispatch_group_wait(group, timeout) != 0 {
-                Log.error("removeAll timed out waiting for disk caches")
+        DispatchQueue.global(qos: DispatchQoS.QoSClass.default).async {
+            let timeout = DispatchTime.now() + Double(Int64(60 * NSEC_PER_SEC)) / Double(NSEC_PER_SEC)
+            if group.wait(timeout: timeout) != .success {
+                Log.error(message: "removeAll timed out waiting for disk caches")
             }
             let path = self.cachePath
             do {
-                try NSFileManager.defaultManager().removeItemAtPath(path)
+                try FileManager.default.removeItem(atPath: path)
             } catch {
-                Log.error("Failed to remove path \(path)", error as NSError)
+                Log.error(message: "Failed to remove path \(path)", error: error)
             }
             if let completion = completion {
-                dispatch_async(dispatch_get_main_queue()) {
+                DispatchQueue.main.async {
                     completion()
                 }
             }
@@ -159,10 +159,10 @@ public class Cache<T: DataConvertible where T.Result == T, T : DataRepresentable
 
     // MARK: Size
 
-    public var size: UInt64 {
+    open var size: UInt64 {
         var size: UInt64 = 0
         for (_, (_, _, diskCache)) in self.formats {
-            dispatch_sync(diskCache.cacheQueue) { size += diskCache.size }
+            diskCache.cacheQueue.sync { size += diskCache.size }
         }
         return size
     }
@@ -177,12 +177,12 @@ public class Cache<T: DataConvertible where T.Result == T, T : DataRepresentable
     
     // MARK: Formats
 
-    var formats : [String : (Format<T>, NSCache, DiskCache)] = [:]
+    var formats : [String : (Format<T>, NSCache<AnyObject, AnyObject>, DiskCache)] = [:]
     
-    public func addFormat(format : Format<T>) {
+    open func addFormat(_ format : Format<T>) {
         let name = format.name
-        let formatPath = self.formatPath(formatName: name)
-        let memoryCache = NSCache()
+        let formatPath = self.formatPath(withFormatName: name)
+        let memoryCache = NSCache<AnyObject, AnyObject>()
         let diskCache = DiskCache(path: formatPath, capacity : format.diskCapacity)
         self.formats[name] = (format, memoryCache, diskCache)
     }
@@ -191,57 +191,57 @@ public class Cache<T: DataConvertible where T.Result == T, T : DataRepresentable
     
     lazy var cachePath: String = {
         let basePath = DiskCache.basePath()
-        let cachePath = (basePath as NSString).stringByAppendingPathComponent(self.name)
+        let cachePath = (basePath as NSString).appendingPathComponent(self.name)
         return cachePath
     }()
     
-    func formatPath(formatName formatName: String) -> String {
-        let formatPath = (self.cachePath as NSString).stringByAppendingPathComponent(formatName)
+    func formatPath(withFormatName formatName: String) -> String {
+        let formatPath = (self.cachePath as NSString).appendingPathComponent(formatName)
         do {
-            try NSFileManager.defaultManager().createDirectoryAtPath(formatPath, withIntermediateDirectories: true, attributes: nil)
+            try FileManager.default.createDirectory(atPath: formatPath, withIntermediateDirectories: true, attributes: nil)
         } catch {
-            Log.error("Failed to create directory \(formatPath)", error as NSError)
+            Log.error(message: "Failed to create directory \(formatPath)", error: error)
         }
         return formatPath
     }
     
     // MARK: Private
     
-    func dataFromValue(value : T, format : Format<T>) -> NSData? {
+    func dataFromValue(_ value : T, format : Format<T>) -> Data? {
         if let data = format.convertToData?(value) {
-            return data
+            return data as Data
         }
         return value.asData()
     }
     
-    private func fetchFromDiskCache(diskCache : DiskCache, key: String, memoryCache : NSCache, failure fail : ((NSError?) -> ())?, success succeed : (T) -> ()) {
+    fileprivate func fetchFromDiskCache(_ diskCache : DiskCache, key: String, memoryCache : NSCache<AnyObject, AnyObject>, failure fail : ((Error?) -> ())?, success succeed : @escaping (T) -> ()) {
         diskCache.fetchData(key: key, failure: { error in
             if let block = fail {
-                if (error?.code == NSFileReadNoSuchFileError) {
+                if (error as? NSError)?.code == NSFileReadNoSuchFileError {
                     let localizedFormat = NSLocalizedString("Object not found for key %@", comment: "Error description")
                     let description = String(format:localizedFormat, key)
-                    let error = errorWithCode(HanekeGlobals.Cache.ErrorCode.ObjectNotFound.rawValue, description: description)
+                    let error = errorWithCode(HanekeGlobals.Cache.ErrorCode.objectNotFound.rawValue, description: description)
                     block(error)
                 } else {
                     block(error)
                 }
             }
         }) { data in
-            dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), {
+            DispatchQueue.global(qos: DispatchQoS.QoSClass.default).async(execute: {
                 let value = T.convertFromData(data)
                 if let value = value {
                     let descompressedValue = self.decompressedImageIfNeeded(value)
-                    dispatch_async(dispatch_get_main_queue(), {
+                    DispatchQueue.main.async(execute: {
                         succeed(descompressedValue)
                         let wrapper = ObjectWrapper(value: descompressedValue)
-                        memoryCache.setObject(wrapper, forKey: key)
+                        memoryCache.setObject(wrapper, forKey: key as AnyObject)
                     })
                 }
             })
         }
     }
     
-    private func fetchAndSet(fetcher : Fetcher<T>, format : Format<T>, failure fail : ((NSError?) -> ())?, success succeed : (T) -> ()) {
+    fileprivate func fetchAndSet(_ fetcher : Fetcher<T>, format : Format<T>, failure fail : ((Error?) -> ())?, success succeed : @escaping (T) -> ()) {
         fetcher.fetch(failure: { error in
             let _ = fail?(error)
         }) { value in
@@ -249,12 +249,12 @@ public class Cache<T: DataConvertible where T.Result == T, T : DataRepresentable
         }
     }
     
-    private func format(value value : T, format : Format<T>, success succeed : (T) -> ()) {
+    fileprivate func format(value : T, format : Format<T>, success succeed : @escaping (T) -> ()) {
         // HACK: Ideally Cache shouldn't treat images differently but I can't think of any other way of doing this that doesn't complicate the API for other types.
         if format.isIdentity && !(value is UIImage) {
             succeed(value)
         } else {
-            dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)) {
+            DispatchQueue.global(qos: DispatchQoS.QoSClass.default).async {
                 var formatted = format.apply(value)
                 
                 if let formattedImage = formatted as? UIImage {
@@ -264,14 +264,14 @@ public class Cache<T: DataConvertible where T.Result == T, T : DataRepresentable
                     }
                 }
                 
-                dispatch_async(dispatch_get_main_queue()) {
+                DispatchQueue.main.async {
                     succeed(formatted)
                 }
             }
         }
     }
     
-    private func decompressedImageIfNeeded(value : T) -> T {
+    fileprivate func decompressedImageIfNeeded(_ value : T) -> T {
         if let image = value as? UIImage {
             let decompressedImage = image.hnk_decompressedImage() as? T
             return decompressedImage!
@@ -279,7 +279,7 @@ public class Cache<T: DataConvertible where T.Result == T, T : DataRepresentable
         return value
     }
     
-    private class func buildFetch(failure fail : Fetch<T>.Failer? = nil, success succeed : Fetch<T>.Succeeder? = nil) -> Fetch<T> {
+    fileprivate class func buildFetch(failure fail : Fetch<T>.Failer? = nil, success succeed : Fetch<T>.Succeeder? = nil) -> Fetch<T> {
         let fetch = Fetch<T>()
         if let succeed = succeed {
             fetch.onSuccess(succeed)
@@ -293,17 +293,17 @@ public class Cache<T: DataConvertible where T.Result == T, T : DataRepresentable
     // MARK: Convenience fetch
     // Ideally we would put each of these in the respective fetcher file as a Cache extension. Unfortunately, this fails to link when using the framework in a project as of Xcode 6.1.
     
-    public func fetch(key key: String, @autoclosure(escaping) value getValue : () -> T.Result, formatName: String = HanekeGlobals.Cache.OriginalFormatName, success succeed : Fetch<T>.Succeeder? = nil) -> Fetch<T> {
+    open func fetch(key: String, value getValue : @autoclosure @escaping () -> T.Result, formatName: String = HanekeGlobals.Cache.OriginalFormatName, success succeed : Fetch<T>.Succeeder? = nil) -> Fetch<T> {
         let fetcher = SimpleFetcher<T>(key: key, value: getValue)
         return self.fetch(fetcher: fetcher, formatName: formatName, success: succeed)
     }
     
-    public func fetch(path path: String, formatName: String = HanekeGlobals.Cache.OriginalFormatName,  failure fail : Fetch<T>.Failer? = nil, success succeed : Fetch<T>.Succeeder? = nil) -> Fetch<T> {
+    open func fetch(path: String, formatName: String = HanekeGlobals.Cache.OriginalFormatName,  failure fail : Fetch<T>.Failer? = nil, success succeed : Fetch<T>.Succeeder? = nil) -> Fetch<T> {
         let fetcher = DiskFetcher<T>(path: path)
         return self.fetch(fetcher: fetcher, formatName: formatName, failure: fail, success: succeed)
     }
     
-    public func fetch(URL URL : NSURL, formatName: String = HanekeGlobals.Cache.OriginalFormatName,  failure fail : Fetch<T>.Failer? = nil, success succeed : Fetch<T>.Succeeder? = nil) -> Fetch<T> {
+    open func fetch(URL : Foundation.URL, formatName: String = HanekeGlobals.Cache.OriginalFormatName,  failure fail : Fetch<T>.Failer? = nil, success succeed : Fetch<T>.Succeeder? = nil) -> Fetch<T> {
         let fetcher = NetworkFetcher<T>(URL: URL)
         return self.fetch(fetcher: fetcher, formatName: formatName, failure: fail, success: succeed)
     }

--- a/Haneke/Log.swift
+++ b/Haneke/Log.swift
@@ -10,28 +10,28 @@ import Foundation
 
 struct Log {
     
-    private static let Tag = "[HANEKE]"
+    fileprivate static let Tag = "[HANEKE]"
     
-    private enum Level : String {
+    fileprivate enum Level : String {
         case Debug = "[DEBUG]"
         case Error = "[ERROR]"
     }
     
-    private static func log(level: Level, @autoclosure _ message: () -> String, _ error: NSError? = nil) {
+    fileprivate static func log(_ level: Level, _ message: @autoclosure () -> String, _ error: Error? = nil) {
         if let error = error {
-            NSLog("%@%@ %@ with error %@", Tag, level.rawValue, message(), error)
+            print("\(Tag)\(level.rawValue) \(message()) with error \(error)")
         } else {
-            NSLog("%@%@ %@", Tag, level.rawValue, message())
+            print("\(Tag)\(level.rawValue) \(message())")
         }
     }
     
-    static func debug(@autoclosure message: () -> String, _ error: NSError? = nil) {
+    static func debug(message: @autoclosure () -> String, error: Error? = nil) {
         #if DEBUG
             log(.Debug, message, error)
         #endif
     }
     
-    static func error(@autoclosure message: () -> String, _ error: NSError? = nil) {
+    static func error(message: @autoclosure () -> String, error: Error? = nil) {
         log(.Error, message, error)
     }
     

--- a/Haneke/NSFileManager+Haneke.swift
+++ b/Haneke/NSFileManager+Haneke.swift
@@ -8,26 +8,26 @@
 
 import Foundation
 
-extension NSFileManager {
+extension FileManager {
 
-    func enumerateContentsOfDirectoryAtPath(path: String, orderedByProperty property: String, ascending: Bool, usingBlock block: (NSURL, Int, inout Bool) -> Void ) {
+    func enumerateContentsOfDirectory(atPath path: String, orderedByProperty property: String, ascending: Bool, usingBlock block: (URL, Int, inout Bool) -> Void ) {
 
-        let directoryURL = NSURL(fileURLWithPath: path)
+        let directoryURL = URL(fileURLWithPath: path)
         do {
-            let contents = try self.contentsOfDirectoryAtURL(directoryURL, includingPropertiesForKeys: [property], options: NSDirectoryEnumerationOptions())
-            let sortedContents = contents.sort({(URL1: NSURL, URL2: NSURL) -> Bool in
+            let contents = try self.contentsOfDirectory(at: directoryURL, includingPropertiesForKeys: [URLResourceKey(rawValue: property)], options: FileManager.DirectoryEnumerationOptions())
+            let sortedContents = contents.sorted(by: {(URL1: URL, URL2: URL) -> Bool in
                 
                 // Maybe there's a better way to do this. See: http://stackoverflow.com/questions/25502914/comparing-anyobject-in-swift
                 
                 var value1 : AnyObject?
                 do {
-                    try URL1.getResourceValue(&value1, forKey: property);
+                    try (URL1 as NSURL).getResourceValue(&value1, forKey: URLResourceKey(rawValue: property))
                 } catch {
                     return true
                 }
                 var value2 : AnyObject?
                 do {
-                    try URL2.getResourceValue(&value2, forKey: property);
+                    try (URL2 as NSURL).getResourceValue(&value2, forKey: URLResourceKey(rawValue: property))
                 } catch {
                     return false
                 }
@@ -36,7 +36,7 @@ extension NSFileManager {
                     return ascending ? string1 < string2 : string2 < string1
                 }
                 
-                if let date1 = value1 as? NSDate, let date2 = value2 as? NSDate {
+                if let date1 = value1 as? Date, let date2 = value2 as? Date {
                     return ascending ? date1 < date2 : date2 < date1
                 }
                 
@@ -47,23 +47,19 @@ extension NSFileManager {
                 return false
             })
             
-            for (i, v) in sortedContents.enumerate() {
+            for (i, v) in sortedContents.enumerated() {
                 var stop : Bool = false
                 block(v, i, &stop)
                 if stop { break }
             }
 
         } catch {
-            Log.error("Failed to list directory", error as NSError)
+            Log.error(message: "Failed to list directory", error: error)
         }
     }
 
 }
 
-func < (lhs: NSDate, rhs: NSDate) -> Bool {
-    return lhs.compare(rhs) == NSComparisonResult.OrderedAscending
-}
-
 func < (lhs: NSNumber, rhs: NSNumber) -> Bool {
-    return lhs.compare(rhs) == NSComparisonResult.OrderedAscending
+    return lhs.compare(rhs) == ComparisonResult.orderedAscending
 }

--- a/Haneke/NSHTTPURLResponse+Haneke.swift
+++ b/Haneke/NSHTTPURLResponse+Haneke.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-extension NSHTTPURLResponse {
+extension HTTPURLResponse {
 
     func hnk_isValidStatusCode() -> Bool {
         switch self.statusCode {

--- a/Haneke/NSURLResponse+Haneke.swift
+++ b/Haneke/NSURLResponse+Haneke.swift
@@ -8,12 +8,12 @@
 
 import Foundation
 
-extension NSURLResponse {
+extension URLResponse {
     
-    func hnk_validateLengthOfData(data: NSData) -> Bool {
+    func hnk_validateLength(ofData data: Data) -> Bool {
         let expectedContentLength = self.expectedContentLength
         if (expectedContentLength > -1) {
-            let dataLength = data.length
+            let dataLength = data.count
             return Int64(dataLength) >= expectedContentLength
         }
         return true

--- a/Haneke/NetworkFetcher.swift
+++ b/Haneke/NetworkFetcher.swift
@@ -14,92 +14,92 @@ extension HanekeGlobals {
     public struct NetworkFetcher {
 
         public enum ErrorCode : Int {
-            case InvalidData = -400
-            case MissingData = -401
-            case InvalidStatusCode = -402
+            case invalidData = -400
+            case missingData = -401
+            case invalidStatusCode = -402
         }
         
     }
     
 }
 
-public class NetworkFetcher<T : DataConvertible> : Fetcher<T> {
+open class NetworkFetcher<T : DataConvertible> : Fetcher<T> {
     
-    let URL : NSURL
+    let URL : Foundation.URL
     
-    public init(URL : NSURL) {
+    public init(URL : Foundation.URL) {
         self.URL = URL
 
         let key =  URL.absoluteString
         super.init(key: key)
     }
     
-    public var session : NSURLSession { return NSURLSession.sharedSession() }
+    open var session : URLSession { return URLSession.shared }
     
-    var task : NSURLSessionDataTask? = nil
+    var task : URLSessionDataTask? = nil
     
     var cancelled = false
     
     // MARK: Fetcher
     
-    public override func fetch(failure fail : ((NSError?) -> ()), success succeed : (T.Result) -> ()) {
+    open override func fetch(failure fail: ((Error?) -> ()), success succeed: @escaping (T.Result) -> ()) {
         self.cancelled = false
-        self.task = self.session.dataTaskWithURL(self.URL) {[weak self] (data, response, error) -> Void in
+        self.task = self.session.dataTask(with: self.URL) {[weak self] (data, response, error) -> Void in
             if let strongSelf = self {
-                strongSelf.onReceiveData(data, response: response, error: error, failure: fail, success: succeed)
+                strongSelf.onReceive(data: data, response: response, error: error, failure: fail, success: succeed)
             }
         }
         self.task?.resume()
     }
     
-    public override func cancelFetch() {
+    open override func cancelFetch() {
         self.task?.cancel()
         self.cancelled = true
     }
     
     // MARK: Private
     
-    private func onReceiveData(data: NSData!, response: NSURLResponse!, error: NSError!, failure fail: ((NSError?) -> ()), success succeed: (T.Result) -> ()) {
+    fileprivate func onReceive(data: Data!, response: URLResponse!, error: Error!, failure fail: ((Error?) -> ()), success succeed: @escaping (T.Result) -> ()) {
 
         if cancelled { return }
         
         let URL = self.URL
         
         if let error = error {
-            if (error.domain == NSURLErrorDomain && error.code == NSURLErrorCancelled) { return }
+            if ((error as NSError).domain == NSURLErrorDomain && (error as NSError).code == NSURLErrorCancelled) { return }
             
-            Log.debug("Request \(URL.absoluteString) failed", error)
-            dispatch_async(dispatch_get_main_queue(), { fail(error) })
+            Log.debug(message: "Request \(URL.absoluteString) failed", error: error)
+            DispatchQueue.main.async(execute: { fail(error) })
             return
         }
         
-        if let httpResponse = response as? NSHTTPURLResponse where !httpResponse.hnk_isValidStatusCode() {
-            let description = NSHTTPURLResponse.localizedStringForStatusCode(httpResponse.statusCode)
-            self.failWithCode(.InvalidStatusCode, localizedDescription: description, failure: fail)
+        if let httpResponse = response as? HTTPURLResponse , !httpResponse.hnk_isValidStatusCode() {
+            let description = HTTPURLResponse.localizedString(forStatusCode: httpResponse.statusCode)
+            self.failWithCode(.invalidStatusCode, localizedDescription: description, failure: fail)
             return
         }
 
-        if !response.hnk_validateLengthOfData(data) {
+        if !response.hnk_validateLength(ofData: data) {
             let localizedFormat = NSLocalizedString("Request expected %ld bytes and received %ld bytes", comment: "Error description")
-            let description = String(format:localizedFormat, response.expectedContentLength, data.length)
-            self.failWithCode(.MissingData, localizedDescription: description, failure: fail)
+            let description = String(format:localizedFormat, response.expectedContentLength, data.count)
+            self.failWithCode(.missingData, localizedDescription: description, failure: fail)
             return
         }
         
         guard let value = T.convertFromData(data) else {
             let localizedFormat = NSLocalizedString("Failed to convert value from data at URL %@", comment: "Error description")
             let description = String(format:localizedFormat, URL.absoluteString)
-            self.failWithCode(.InvalidData, localizedDescription: description, failure: fail)
+            self.failWithCode(.invalidData, localizedDescription: description, failure: fail)
             return
         }
 
-        dispatch_async(dispatch_get_main_queue()) { succeed(value) }
+        DispatchQueue.main.async { succeed(value) }
 
     }
     
-    private func failWithCode(code: HanekeGlobals.NetworkFetcher.ErrorCode, localizedDescription: String, failure fail: ((NSError?) -> ())) {
+    fileprivate func failWithCode(_ code: HanekeGlobals.NetworkFetcher.ErrorCode, localizedDescription: String, failure fail: ((Error?) -> ())) {
         let error = errorWithCode(code.rawValue, description: localizedDescription)
-        Log.debug(localizedDescription, error)
-        dispatch_async(dispatch_get_main_queue()) { fail(error) }
+        Log.debug(message: localizedDescription, error: error)
+        DispatchQueue.main.async { fail(error) }
     }
 }

--- a/Haneke/NetworkFetcher.swift
+++ b/Haneke/NetworkFetcher.swift
@@ -42,7 +42,7 @@ open class NetworkFetcher<T : DataConvertible> : Fetcher<T> {
     
     // MARK: Fetcher
     
-    open override func fetch(failure fail: ((Error?) -> ()), success succeed: @escaping (T.Result) -> ()) {
+    open override func fetch(failure fail: @escaping ((Error?) -> ()), success succeed: @escaping (T.Result) -> ()) {
         self.cancelled = false
         self.task = self.session.dataTask(with: self.URL) {[weak self] (data, response, error) -> Void in
             if let strongSelf = self {
@@ -59,7 +59,7 @@ open class NetworkFetcher<T : DataConvertible> : Fetcher<T> {
     
     // MARK: Private
     
-    fileprivate func onReceive(data: Data!, response: URLResponse!, error: Error!, failure fail: ((Error?) -> ()), success succeed: @escaping (T.Result) -> ()) {
+    fileprivate func onReceive(data: Data!, response: URLResponse!, error: Error!, failure fail: @escaping ((Error?) -> ()), success succeed: @escaping (T.Result) -> ()) {
 
         if cancelled { return }
         
@@ -97,7 +97,7 @@ open class NetworkFetcher<T : DataConvertible> : Fetcher<T> {
 
     }
     
-    fileprivate func failWithCode(_ code: HanekeGlobals.NetworkFetcher.ErrorCode, localizedDescription: String, failure fail: ((Error?) -> ())) {
+    fileprivate func failWithCode(_ code: HanekeGlobals.NetworkFetcher.ErrorCode, localizedDescription: String, failure fail: @escaping ((Error?) -> ())) {
         let error = errorWithCode(code.rawValue, description: localizedDescription)
         Log.debug(message: localizedDescription, error: error)
         DispatchQueue.main.async { fail(error) }

--- a/Haneke/String+Haneke.swift
+++ b/Haneke/String+Haneke.swift
@@ -12,20 +12,20 @@ extension String {
     
     func escapedFilename() -> String {
         return [ "\0":"%00", ":":"%3A", "/":"%2F" ]
-            .reduce(self.componentsSeparatedByString("%").joinWithSeparator("%25")) {
-                str, m in str.componentsSeparatedByString(m.0).joinWithSeparator(m.1)
+            .reduce(self.components(separatedBy: "%").joined(separator: "%25")) {
+                str, m in str.components(separatedBy: m.0).joined(separator: m.1)
         }
     }
     
     func MD5String() -> String {
-        guard let data = self.dataUsingEncoding(NSUTF8StringEncoding) else {
+        guard let data = self.data(using: String.Encoding.utf8) else {
             return self
         }
 
-        let MD5Calculator = MD5(data)
+        let MD5Calculator = MD5(Array(data))
         let MD5Data = MD5Calculator.calculate()
-        let resultBytes = UnsafeMutablePointer<CUnsignedChar>(MD5Data.bytes)
-        let resultEnumerator = UnsafeBufferPointer<CUnsignedChar>(start: resultBytes, count: MD5Data.length)
+        let resultBytes = UnsafeMutablePointer<CUnsignedChar>(mutating: MD5Data)
+        let resultEnumerator = UnsafeBufferPointer<CUnsignedChar>(start: resultBytes, count: MD5Data.count)
         let MD5String = NSMutableString()
         for c in resultEnumerator {
             MD5String.appendFormat("%02x", c)
@@ -37,10 +37,10 @@ extension String {
         let MD5String = self.MD5String()
 
         // NSString.pathExtension alone could return a query string, which can lead to very long filenames.
-        let pathExtension = NSURL(string: self)?.pathExtension ?? (self as NSString).pathExtension
+        let pathExtension = URL(string: self)?.pathExtension ?? (self as NSString).pathExtension
 
         if pathExtension.characters.count > 0 {
-            return (MD5String as NSString).stringByAppendingPathExtension(pathExtension) ?? MD5String
+            return (MD5String as NSString).appendingPathExtension(pathExtension) ?? MD5String
         } else {
             return MD5String
         }

--- a/Haneke/UIButton+Haneke.swift
+++ b/Haneke/UIButton+Haneke.swift
@@ -21,22 +21,22 @@ public extension UIButton {
             return HanekeGlobals.UIKit.formatWithSize(imageSize, scaleMode: scaleMode, allowUpscaling: scaleMode == ImageResizer.ScaleMode.AspectFit ? false : true)
     }
     
-    public func hnk_setImageFromURL(_ URL: Foundation.URL, state: UIControlState = UIControlState(), placeholder: UIImage? = nil, format: Format<UIImage>? = nil, failure fail: ((Error?) -> ())? = nil, success succeed: ((UIImage) -> ())? = nil) {
+    public func hnk_setImageFromURL(_ URL: Foundation.URL, state: UIControlState = .normal, placeholder: UIImage? = nil, format: Format<UIImage>? = nil, failure fail: ((Error?) -> ())? = nil, success succeed: ((UIImage) -> ())? = nil) {
         let fetcher = NetworkFetcher<UIImage>(URL: URL)
         self.hnk_setImageFromFetcher(fetcher, state: state, placeholder: placeholder, format: format, failure: fail, success: succeed)
     }
     
-    public func hnk_setImage(_ image: UIImage, key: String, state: UIControlState = UIControlState(), placeholder: UIImage? = nil, format: Format<UIImage>? = nil, success succeed: ((UIImage) -> ())? = nil) {
+    public func hnk_setImage(_ image: UIImage, key: String, state: UIControlState = .normal, placeholder: UIImage? = nil, format: Format<UIImage>? = nil, success succeed: ((UIImage) -> ())? = nil) {
         let fetcher = SimpleFetcher<UIImage>(key: key, value: image)
         self.hnk_setImageFromFetcher(fetcher, state: state, placeholder: placeholder, format: format, success: succeed)
     }
     
-    public func hnk_setImageFromFile(_ path: String, state: UIControlState = UIControlState(), placeholder: UIImage? = nil, format: Format<UIImage>? = nil, failure fail: ((Error?) -> ())? = nil, success succeed: ((UIImage) -> ())? = nil) {
+    public func hnk_setImageFromFile(_ path: String, state: UIControlState = .normal, placeholder: UIImage? = nil, format: Format<UIImage>? = nil, failure fail: ((Error?) -> ())? = nil, success succeed: ((UIImage) -> ())? = nil) {
         let fetcher = DiskFetcher<UIImage>(path: path)
         self.hnk_setImageFromFetcher(fetcher, state: state, placeholder: placeholder, format: format, failure: fail, success: succeed)
     }
     
-    public func hnk_setImageFromFetcher(_ fetcher: Fetcher<UIImage>, state: UIControlState = UIControlState(), placeholder: UIImage? = nil, format: Format<UIImage>? = nil, failure fail: ((Error?) -> ())? = nil, success succeed: ((UIImage) -> ())? = nil){
+    public func hnk_setImageFromFetcher(_ fetcher: Fetcher<UIImage>, state: UIControlState = .normal, placeholder: UIImage? = nil, format: Format<UIImage>? = nil, failure fail: ((Error?) -> ())? = nil, success succeed: ((UIImage) -> ())? = nil){
         self.hnk_cancelSetImage()
         self.hnk_imageFetcher = fetcher
         
@@ -74,7 +74,7 @@ public extension UIButton {
         }
     }
     
-    func hnk_fetchImageForFetcher(_ fetcher : Fetcher<UIImage>, state : UIControlState = UIControlState(), format : Format<UIImage>? = nil, failure fail : ((Error?) -> ())?, success succeed : ((UIImage) -> ())?) -> Bool {
+    func hnk_fetchImageForFetcher(_ fetcher : Fetcher<UIImage>, state : UIControlState = .normal, format : Format<UIImage>? = nil, failure fail : ((Error?) -> ())?, success succeed : ((UIImage) -> ())?) -> Bool {
         let format = format ?? self.hnk_imageFormat
         let cache = Shared.imageCache
         if cache.formats[format.name] == nil {
@@ -132,22 +132,22 @@ public extension UIButton {
             return HanekeGlobals.UIKit.formatWithSize(imageSize, scaleMode: .Fill)
     }
     
-    public func hnk_setBackgroundImageFromURL(_ URL : Foundation.URL, state : UIControlState = UIControlState(), placeholder : UIImage? = nil, format : Format<UIImage>? = nil, failure fail : ((Error?) -> ())? = nil, success succeed : ((UIImage) -> ())? = nil) {
+    public func hnk_setBackgroundImageFromURL(_ URL : Foundation.URL, state : UIControlState = .normal, placeholder : UIImage? = nil, format : Format<UIImage>? = nil, failure fail : ((Error?) -> ())? = nil, success succeed : ((UIImage) -> ())? = nil) {
         let fetcher = NetworkFetcher<UIImage>(URL: URL)
         self.hnk_setBackgroundImageFromFetcher(fetcher, state: state, placeholder: placeholder, format: format, failure: fail, success: succeed)
     }
     
-    public func hnk_setBackgroundImage(_ image : UIImage, key: String, state : UIControlState = UIControlState(), placeholder : UIImage? = nil, format : Format<UIImage>? = nil, success succeed : ((UIImage) -> ())? = nil) {
+    public func hnk_setBackgroundImage(_ image : UIImage, key: String, state : UIControlState = .normal, placeholder : UIImage? = nil, format : Format<UIImage>? = nil, success succeed : ((UIImage) -> ())? = nil) {
         let fetcher = SimpleFetcher<UIImage>(key: key, value: image)
         self.hnk_setBackgroundImageFromFetcher(fetcher, state: state, placeholder: placeholder, format: format, success: succeed)
     }
     
-    public func hnk_setBackgroundImageFromFile(_ path: String, state : UIControlState = UIControlState(), placeholder : UIImage? = nil, format : Format<UIImage>? = nil, failure fail : ((Error?) -> ())? = nil, success succeed : ((UIImage) -> ())? = nil) {
+    public func hnk_setBackgroundImageFromFile(_ path: String, state : UIControlState = .normal, placeholder : UIImage? = nil, format : Format<UIImage>? = nil, failure fail : ((Error?) -> ())? = nil, success succeed : ((UIImage) -> ())? = nil) {
         let fetcher = DiskFetcher<UIImage>(path: path)
         self.hnk_setBackgroundImageFromFetcher(fetcher, state: state, placeholder: placeholder, format: format, failure: fail, success: succeed)
     }
     
-    public func hnk_setBackgroundImageFromFetcher(_ fetcher : Fetcher<UIImage>, state : UIControlState = UIControlState(), placeholder : UIImage? = nil, format : Format<UIImage>? = nil, failure fail : ((Error?) -> ())? = nil, success succeed : ((UIImage) -> ())? = nil) {
+    public func hnk_setBackgroundImageFromFetcher(_ fetcher : Fetcher<UIImage>, state : UIControlState = .normal, placeholder : UIImage? = nil, format : Format<UIImage>? = nil, failure fail : ((Error?) -> ())? = nil, success succeed : ((UIImage) -> ())? = nil) {
         self.hnk_cancelSetBackgroundImage()
         self.hnk_backgroundImageFetcher = fetcher
         
@@ -185,7 +185,7 @@ public extension UIButton {
         }
     }
     
-    func hnk_fetchBackgroundImageForFetcher(_ fetcher: Fetcher<UIImage>, state: UIControlState = UIControlState(), format: Format<UIImage>? = nil, failure fail: ((Error?) -> ())?, success succeed : ((UIImage) -> ())?) -> Bool {
+    func hnk_fetchBackgroundImageForFetcher(_ fetcher: Fetcher<UIImage>, state: UIControlState = .normal, format: Format<UIImage>? = nil, failure fail: ((Error?) -> ())?, success succeed : ((UIImage) -> ())?) -> Bool {
         let format = format ?? self.hnk_backgroundImageFormat
         let cache = Shared.imageCache
         if cache.formats[format.name] == nil {

--- a/Haneke/UIImage+Haneke.swift
+++ b/Haneke/UIImage+Haneke.swift
@@ -10,71 +10,71 @@ import UIKit
 
 extension UIImage {
 
-    func hnk_imageByScalingToSize(toSize: CGSize) -> UIImage {
-        UIGraphicsBeginImageContextWithOptions(toSize, !hnk_hasAlpha(), 0.0)
-        drawInRect(CGRectMake(0, 0, toSize.width, toSize.height))
+    func hnk_imageByScaling(toSize size: CGSize) -> UIImage {
+        UIGraphicsBeginImageContextWithOptions(size, !hnk_hasAlpha(), 0.0)
+        draw(in: CGRect(x: 0, y: 0, width: size.width, height: size.height))
         let resizedImage = UIGraphicsGetImageFromCurrentImageContext()
         UIGraphicsEndImageContext()
-        return resizedImage
+        return resizedImage!
     }
 
     func hnk_hasAlpha() -> Bool {
-        let alpha = CGImageGetAlphaInfo(self.CGImage)
-        switch alpha {
-        case .First, .Last, .PremultipliedFirst, .PremultipliedLast, .Only:
+        guard let alphaInfo = self.cgImage?.alphaInfo else { return false }
+        switch alphaInfo {
+        case .first, .last, .premultipliedFirst, .premultipliedLast, .alphaOnly:
             return true
-        case .None, .NoneSkipFirst, .NoneSkipLast:
+        case .none, .noneSkipFirst, .noneSkipLast:
             return false
         }
     }
     
-    func hnk_data(compressionQuality compressionQuality: Float = 1.0) -> NSData! {
+    func hnk_data(compressionQuality: Float = 1.0) -> Data! {
         let hasAlpha = self.hnk_hasAlpha()
         let data = hasAlpha ? UIImagePNGRepresentation(self) : UIImageJPEGRepresentation(self, CGFloat(compressionQuality))
         return data
     }
     
     func hnk_decompressedImage() -> UIImage! {
-        let originalImageRef = self.CGImage
-        let originalBitmapInfo = CGImageGetBitmapInfo(originalImageRef)
-        let alphaInfo = CGImageGetAlphaInfo(originalImageRef)
+        let originalImageRef = self.cgImage
+        let originalBitmapInfo = originalImageRef?.bitmapInfo
+        guard let alphaInfo = originalImageRef?.alphaInfo else { return UIImage() }
         
         // See: http://stackoverflow.com/questions/23723564/which-cgimagealphainfo-should-we-use
         var bitmapInfo = originalBitmapInfo
-        switch (alphaInfo) {
-        case .None:
-            let rawBitmapInfoWithoutAlpha = bitmapInfo.rawValue & ~CGBitmapInfo.AlphaInfoMask.rawValue
-            let rawBitmapInfo = rawBitmapInfoWithoutAlpha | CGImageAlphaInfo.NoneSkipFirst.rawValue
+        switch alphaInfo {
+        case .none:
+            let rawBitmapInfoWithoutAlpha = (bitmapInfo?.rawValue)! & ~CGBitmapInfo.alphaInfoMask.rawValue
+            let rawBitmapInfo = rawBitmapInfoWithoutAlpha | CGImageAlphaInfo.noneSkipFirst.rawValue
             bitmapInfo = CGBitmapInfo(rawValue: rawBitmapInfo)
-        case .PremultipliedFirst, .PremultipliedLast, .NoneSkipFirst, .NoneSkipLast:
+        case .premultipliedFirst, .premultipliedLast, .noneSkipFirst, .noneSkipLast:
             break
-        case .Only, .Last, .First: // Unsupported
+        case .alphaOnly, .last, .first: // Unsupported
             return self
         }
         
         let colorSpace = CGColorSpaceCreateDeviceRGB()
-        let pixelSize = CGSizeMake(self.size.width * self.scale, self.size.height * self.scale)
-        guard let context = CGBitmapContextCreate(nil, Int(ceil(pixelSize.width)), Int(ceil(pixelSize.height)), CGImageGetBitsPerComponent(originalImageRef), 0, colorSpace, bitmapInfo.rawValue) else {
+        let pixelSize = CGSize(width: self.size.width * self.scale, height: self.size.height * self.scale)
+        guard let context = CGContext(data: nil, width: Int(ceil(pixelSize.width)), height: Int(ceil(pixelSize.height)), bitsPerComponent: (originalImageRef?.bitsPerComponent)!, bytesPerRow: 0, space: colorSpace, bitmapInfo: (bitmapInfo?.rawValue)!) else {
             return self
         }
 
-        let imageRect = CGRectMake(0, 0, pixelSize.width, pixelSize.height)
+        let imageRect = CGRect(x: 0, y: 0, width: pixelSize.width, height: pixelSize.height)
         UIGraphicsPushContext(context)
         
         // Flip coordinate system. See: http://stackoverflow.com/questions/506622/cgcontextdrawimage-draws-image-upside-down-when-passed-uiimage-cgimage
-        CGContextTranslateCTM(context, 0, pixelSize.height)
-        CGContextScaleCTM(context, 1.0, -1.0)
+        context.translateBy(x: 0, y: pixelSize.height)
+        context.scaleBy(x: 1.0, y: -1.0)
         
         // UIImage and drawInRect takes into account image orientation, unlike CGContextDrawImage.
-        self.drawInRect(imageRect)
+        self.draw(in: imageRect)
         UIGraphicsPopContext()
         
-        guard let decompressedImageRef = CGBitmapContextCreateImage(context) else {
+        guard let decompressedImageRef = context.makeImage() else {
             return self
         }
         
-        let scale = UIScreen.mainScreen().scale
-        let image = UIImage(CGImage: decompressedImageRef, scale:scale, orientation:UIImageOrientation.Up)
+        let scale = UIScreen.main.scale
+        let image = UIImage(cgImage: decompressedImageRef, scale:scale, orientation:UIImageOrientation.up)
         return image
     }
 

--- a/Haneke/UIImageView+Haneke.swift
+++ b/Haneke/UIImageView+Haneke.swift
@@ -17,25 +17,25 @@ public extension UIImageView {
             return HanekeGlobals.UIKit.formatWithSize(viewSize, scaleMode: scaleMode)
     }
     
-    public func hnk_setImageFromURL(URL: NSURL, placeholder : UIImage? = nil, format : Format<UIImage>? = nil, failure fail : ((NSError?) -> ())? = nil, success succeed : ((UIImage) -> ())? = nil) {
+    public func hnk_setImageFromURL(_ URL: Foundation.URL, placeholder : UIImage? = nil, format : Format<UIImage>? = nil, failure fail : ((Error?) -> ())? = nil, success succeed : ((UIImage) -> ())? = nil) {
         let fetcher = NetworkFetcher<UIImage>(URL: URL)
-        self.hnk_setImageFromFetcher(fetcher, placeholder: placeholder, format: format, failure: fail, success: succeed)
+        self.hnk_setImage(fromFetcher: fetcher, placeholder: placeholder, format: format, failure: fail, success: succeed)
     }
     
-    public func hnk_setImage(@autoclosure(escaping) image: () -> UIImage, key: String, placeholder : UIImage? = nil, format : Format<UIImage>? = nil, success succeed : ((UIImage) -> ())? = nil) {
+    public func hnk_setImage( _ image: @autoclosure @escaping () -> UIImage, key: String, placeholder : UIImage? = nil, format : Format<UIImage>? = nil, success succeed : ((UIImage) -> ())? = nil) {
         let fetcher = SimpleFetcher<UIImage>(key: key, value: image)
-        self.hnk_setImageFromFetcher(fetcher, placeholder: placeholder, format: format, success: succeed)
+        self.hnk_setImage(fromFetcher: fetcher, placeholder: placeholder, format: format, success: succeed)
     }
     
-    public func hnk_setImageFromFile(path: String, placeholder : UIImage? = nil, format : Format<UIImage>? = nil, failure fail : ((NSError?) -> ())? = nil, success succeed : ((UIImage) -> ())? = nil) {
+    public func hnk_setImageFromFile(_ path: String, placeholder : UIImage? = nil, format : Format<UIImage>? = nil, failure fail : ((Error?) -> ())? = nil, success succeed : ((UIImage) -> ())? = nil) {
         let fetcher = DiskFetcher<UIImage>(path: path)
-        self.hnk_setImageFromFetcher(fetcher, placeholder: placeholder, format: format, failure: fail, success: succeed)
+        self.hnk_setImage(fromFetcher: fetcher, placeholder: placeholder, format: format, failure: fail, success: succeed)
     }
     
-    public func hnk_setImageFromFetcher(fetcher : Fetcher<UIImage>,
+    public func hnk_setImage(fromFetcher fetcher : Fetcher<UIImage>,
         placeholder : UIImage? = nil,
         format : Format<UIImage>? = nil,
-        failure fail : ((NSError?) -> ())? = nil,
+        failure fail : ((Error?) -> ())? = nil,
         success succeed : ((UIImage) -> ())? = nil) {
 
         self.hnk_cancelSetImage()
@@ -64,7 +64,7 @@ public extension UIImageView {
     var hnk_fetcher : Fetcher<UIImage>! {
         get {
             let wrapper = objc_getAssociatedObject(self, &HanekeGlobals.UIKit.SetImageFetcherKey) as? ObjectWrapper
-            let fetcher = wrapper?.value as? Fetcher<UIImage>
+            let fetcher = wrapper?.hnk_value as? Fetcher<UIImage>
             return fetcher
         }
         set (fetcher) {
@@ -78,18 +78,18 @@ public extension UIImageView {
     
     public var hnk_scaleMode : ImageResizer.ScaleMode {
         switch (self.contentMode) {
-        case .ScaleToFill:
+        case .scaleToFill:
             return .Fill
-        case .ScaleAspectFit:
+        case .scaleAspectFit:
             return .AspectFit
-        case .ScaleAspectFill:
+        case .scaleAspectFill:
             return .AspectFill
-        case .Redraw, .Center, .Top, .Bottom, .Left, .Right, .TopLeft, .TopRight, .BottomLeft, .BottomRight:
+        case .redraw, .center, .top, .bottom, .left, .right, .topLeft, .topRight, .bottomLeft, .bottomRight:
             return .None
             }
     }
 
-    func hnk_fetchImageForFetcher(fetcher : Fetcher<UIImage>, format : Format<UIImage>? = nil, failure fail : ((NSError?) -> ())?, success succeed : ((UIImage) -> ())?) -> Bool {
+    func hnk_fetchImageForFetcher(_ fetcher : Fetcher<UIImage>, format : Format<UIImage>? = nil, failure fail : ((Error?) -> ())?, success succeed : ((UIImage) -> ())?) -> Bool {
         let cache = Shared.imageCache
         let format = format ?? self.hnk_format
         if cache.formats[format.name] == nil {
@@ -98,7 +98,7 @@ public extension UIImageView {
         var animated = false
         let fetch = cache.fetch(fetcher: fetcher, formatName: format.name, failure: {[weak self] error in
             if let strongSelf = self {
-                if strongSelf.hnk_shouldCancelForKey(fetcher.key) { return }
+                if strongSelf.hnk_shouldCancel(forKey: fetcher.key) { return }
                 
                 strongSelf.hnk_fetcher = nil
                 
@@ -106,7 +106,7 @@ public extension UIImageView {
             }
         }) { [weak self] image in
             if let strongSelf = self {
-                if strongSelf.hnk_shouldCancelForKey(fetcher.key) { return }
+                if strongSelf.hnk_shouldCancel(forKey: fetcher.key) { return }
                 
                 strongSelf.hnk_setImage(image, animated: animated, success: succeed)
             }
@@ -115,13 +115,13 @@ public extension UIImageView {
         return fetch.hasSucceeded
     }
     
-    func hnk_setImage(image : UIImage, animated : Bool, success succeed : ((UIImage) -> ())?) {
+    func hnk_setImage(_ image : UIImage, animated : Bool, success succeed : ((UIImage) -> ())?) {
         self.hnk_fetcher = nil
         
         if let succeed = succeed {
             succeed(image)
         } else if animated {
-            UIView.transitionWithView(self, duration: HanekeGlobals.UIKit.SetImageAnimationDuration, options: .TransitionCrossDissolve, animations: {
+            UIView.transition(with: self, duration: HanekeGlobals.UIKit.SetImageAnimationDuration, options: .transitionCrossDissolve, animations: {
                 self.image = image
             }, completion: nil)
         } else {
@@ -129,10 +129,10 @@ public extension UIImageView {
         }
     }
     
-    func hnk_shouldCancelForKey(key:String) -> Bool {
+    func hnk_shouldCancel(forKey key:String) -> Bool {
         if self.hnk_fetcher?.key == key { return false }
         
-        Log.debug("Cancelled set image for \((key as NSString).lastPathComponent)")
+        Log.debug(message: "Cancelled set image for \((key as NSString).lastPathComponent)")
         return true
     }
     

--- a/Haneke/UIView+Haneke.swift
+++ b/Haneke/UIView+Haneke.swift
@@ -12,7 +12,7 @@ public extension HanekeGlobals {
     
     public struct UIKit {
         
-        static func formatWithSize(size : CGSize, scaleMode : ImageResizer.ScaleMode, allowUpscaling: Bool = true) -> Format<UIImage> {
+        static func formatWithSize(_ size : CGSize, scaleMode : ImageResizer.ScaleMode, allowUpscaling: Bool = true) -> Format<UIImage> {
             let name = "auto-\(size.width)x\(size.height)-\(scaleMode.rawValue)"
             let cache = Shared.imageCache
             if let (format,_,_) = cache.formats[name] {
@@ -27,8 +27,8 @@ public extension HanekeGlobals {
                         compressionQuality: HanekeGlobals.UIKit.DefaultFormat.CompressionQuality)
                     return resizer.resizeImage($0)
             }
-            format.convertToData = {(image : UIImage) -> NSData in
-                image.hnk_data(compressionQuality: HanekeGlobals.UIKit.DefaultFormat.CompressionQuality)
+            format.convertToData = {(image : UIImage) -> Data in
+                image.hnk_data(compressionQuality: HanekeGlobals.UIKit.DefaultFormat.CompressionQuality) as Data
             }
             return format
         }

--- a/HanekeDemo/AppDelegate.swift
+++ b/HanekeDemo/AppDelegate.swift
@@ -13,7 +13,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?
 
-    func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
         return true
     }

--- a/HanekeDemo/CollectionViewCell.swift
+++ b/HanekeDemo/CollectionViewCell.swift
@@ -26,8 +26,8 @@ class CollectionViewCell: UICollectionViewCell {
     func initHelper() {
         imageView = UIImageView(frame: self.contentView.bounds)
         imageView.clipsToBounds = true
-        imageView.contentMode = .ScaleAspectFill
-        imageView.autoresizingMask = [.FlexibleWidth, .FlexibleHeight]
+        imageView.contentMode = .scaleAspectFill
+        imageView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         self.contentView.addSubview(imageView)
     }
     

--- a/HanekeDemo/ViewController.swift
+++ b/HanekeDemo/ViewController.swift
@@ -34,7 +34,7 @@ class ViewController: UICollectionViewController {
         let CellIdentifier = "Cell"
         let cell = collectionView.dequeueReusableCellWithReuseIdentifier(CellIdentifier, forIndexPath: indexPath) as! CollectionViewCell
         let URLString = self.items[indexPath.row]
-        let URL = NSURL(string:URLString)!
+        let URL = URL(string:URLString)!
         cell.imageView.hnk_setImageFromURL(URL)
         return cell
     }

--- a/HanekeDemo/ViewController.swift
+++ b/HanekeDemo/ViewController.swift
@@ -16,9 +16,9 @@ class ViewController: UICollectionViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.collectionView!.registerClass(CollectionViewCell.self, forCellWithReuseIdentifier: CellReuseIdentifier)
+        self.collectionView!.register(CollectionViewCell.self, forCellWithReuseIdentifier: CellReuseIdentifier)
         let layout = UICollectionViewFlowLayout()
-        layout.itemSize = CGSizeMake(100, 100)
+        layout.itemSize = CGSize(width: 100, height: 100)
         self.collectionView!.collectionViewLayout = layout
         
         self.initializeItemsWithURLs()
@@ -26,16 +26,16 @@ class ViewController: UICollectionViewController {
 
     // MARK: UIViewCollectionViewDataSource
     
-    override func collectionView(collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+    override func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         return items.count
     }
     
-    override func collectionView(collectionView: UICollectionView, cellForItemAtIndexPath indexPath: NSIndexPath) -> UICollectionViewCell {
+    override func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let CellIdentifier = "Cell"
-        let cell = collectionView.dequeueReusableCellWithReuseIdentifier(CellIdentifier, forIndexPath: indexPath) as! CollectionViewCell
-        let URLString = self.items[indexPath.row]
-        let URL = URL(string:URLString)!
-        cell.imageView.hnk_setImageFromURL(URL)
+        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: CellIdentifier, for: indexPath) as! CollectionViewCell
+        let URLString = self.items[(indexPath as NSIndexPath).row]
+        let url = URL(string:URLString)!
+        cell.imageView.hnk_setImageFromURL(url)
         return cell
     }
     

--- a/HanekeTests/AsyncFetcher.swift
+++ b/HanekeTests/AsyncFetcher.swift
@@ -13,15 +13,15 @@ class AsyncFetcher<T : DataConvertible> : Fetcher<T> {
 
     let getValue : () -> T.Result
 
-    init(key: String, @autoclosure(escaping) value getValue : () -> T.Result) {
+    init(key: String, value getValue : @autoclosure @escaping () -> T.Result) {
         self.getValue = getValue
         super.init(key: key)
     }
 
-    override func fetch(failure fail: ((NSError?) -> ()), success succeed: (T.Result) -> ()) {
+    override func fetch(failure fail: ((Error?) -> ()), success succeed: (T.Result) -> ()) {
         let value = getValue()
-        dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)) {
-            dispatch_async(dispatch_get_main_queue()) {
+        DispatchQueue.global(priority: DispatchQueue.GlobalQueuePriority.default).async {
+            DispatchQueue.main.async {
                 succeed(value)
             }
         }

--- a/HanekeTests/CGSize+HanekeTests.swift
+++ b/HanekeTests/CGSize+HanekeTests.swift
@@ -13,15 +13,15 @@ import XCTest
 class CGSize_HanekeTests: XCTestCase {
     
     func testAspectFillSize() {
-        let image = UIImage.imageWithColor(UIColor.redColor(), CGSize(width: 10, height: 1), false)
-        let sut: CGSize = image.size.hnk_aspectFillSize(CGSizeMake(10, 10))
+        let image = UIImage.imageWithColor(UIColor.red, false, CGSize(width: 10, height: 1))
+        let sut: CGSize = image.size.hnk_aspectFillSize(CGSize(width: 10, height: 10))
         
         XCTAssertTrue(sut.height == 10)
     }
     
     func testAspectFitSize() {
-        let image = UIImage.imageWithColor(UIColor.redColor(), CGSize(width: 10, height: 1), false)
-        let sut: CGSize = image.size.hnk_aspectFitSize(CGSizeMake(20, 20))
+        let image = UIImage.imageWithColor(UIColor.red, false, CGSize(width: 10, height: 1))
+        let sut: CGSize = image.size.hnk_aspectFitSize(CGSize(width: 20, height: 20))
         
         XCTAssertTrue(sut.height == 2)
     }

--- a/HanekeTests/CacheTests.swift
+++ b/HanekeTests/CacheTests.swift
@@ -1,5 +1,5 @@
 //
-//  CacheTests.swift
+//  HanekeCacheTests.swift
 //  Haneke
 //
 //  Created by Luis Ascorbe on 23/07/14.
@@ -11,13 +11,13 @@ import UIKit
 import XCTest
 @testable import Haneke
 
-class CacheTests: XCTestCase {
+class HanekeCacheTests: XCTestCase {
     
-    var sut : Cache<NSData>!
+    var sut : HanekeCache<Data>!
     
     override func setUp() {
         super.setUp()
-        sut = Cache<NSData>(name: self.name!)
+        sut = HanekeCache<Data>(name: self.name!)
     }
     
     override func tearDown() {
@@ -33,7 +33,7 @@ class CacheTests: XCTestCase {
     
     func testInit() {
         let name = "name"
-        let sut = Cache<NSData>(name: name)
+        let sut = HanekeCache<Data>(name: name)
         
         XCTAssertNotNil(sut.memoryWarningObserver)
         XCTAssertEqual(name, sut.name)
@@ -41,21 +41,21 @@ class CacheTests: XCTestCase {
     }
     
     func testDeinit() {
-        weak var _ = Cache<UIImage>(name: self.name!)
+        weak var _ = HanekeCache<UIImage>(name: self.name!)
     }
     
-    // MARK: cachePath
+    // MARK: HanekeCachePath
     
-    func testCachePath() {
-        let expectedCachePath = (DiskCache.basePath() as NSString).stringByAppendingPathComponent(sut.name)
-        XCTAssertEqual(sut.cachePath, expectedCachePath)
+    func testHanekeCachePath() {
+        let expectedHanekeCachePath = (DiskHanekeCache.basePath() as NSString).appendingPathComponent(sut.name)
+        XCTAssertEqual(sut.HanekeCachePath, expectedHanekeCachePath)
     }
     
     // MARK: formatPath
     
     func testFormatPath() {
         let formatName = self.name!
-        let expectedFormatPath = (sut.cachePath as NSString).stringByAppendingPathComponent(formatName)
+        let expectedFormatPath = (sut.HanekeCachePath as NSString).appendingPathComponent(formatName)
         
         let formatPath = sut.formatPath(formatName: formatName)
         
@@ -64,7 +64,7 @@ class CacheTests: XCTestCase {
     
     func testFormatPath_WithEmptyName() {
         let formatName = ""
-        let expectedFormatPath = (sut.cachePath as NSString).stringByAppendingPathComponent(formatName)
+        let expectedFormatPath = (sut.HanekeCachePath as NSString).appendingPathComponent(formatName)
         
         let formatPath = sut.formatPath(formatName: formatName)
         
@@ -74,7 +74,7 @@ class CacheTests: XCTestCase {
     // MARK: addFormat
     
     func testAddFormat() {
-        let format = Format<NSData>(name: self.name!)
+        let format = Format<Data>(name: self.name!)
         
         sut.addFormat(format)
     }
@@ -82,9 +82,9 @@ class CacheTests: XCTestCase {
     // size
 
     func testSize_WithOneFormat() {
-        let data = NSData.dataWithLength(6)
+        let data = Data.dataWithLength(6)
         let key = self.name
-        let format = Format<NSData>(name: self.name)
+        let format = Format<Data>(name: self.name)
         sut.addFormat(format)
 
         var finished = false
@@ -93,20 +93,20 @@ class CacheTests: XCTestCase {
         })
 
         XCTAssert(finished, "set completed not in main queue")
-        XCTAssertEqual(sut.size, UInt64(data.length))
+        XCTAssertEqual(sut.size, UInt64(data.count))
     }
 
     func testSize_WithTwoFormats() {
         let lengths = [4, 7]
-        let formats = (0..<lengths.count).map { (index: Int) -> Format<NSData> in
-            let formatName = self.name + String(index)
-            return Format<NSData>(name: formatName)
+        let formats = (0..<lengths.count).map { (index: Int) -> Format<Data> in
+            let formatName = self.name! + String(index)
+            return Format<Data>(name: formatName)
         }
         formats.forEach(sut.addFormat)
         let lenghtsByFormats = zip(lengths, formats)
 
-        lenghtsByFormats.forEach { (length: Int, format: Format<NSData>) in
-            let data = NSData.dataWithLength(length)
+        lenghtsByFormats.forEach { (length: Int, format: Format<Data>) in
+            let data = Data.dataWithLength(length)
             let key = self.name
 
             var finished = false
@@ -117,32 +117,32 @@ class CacheTests: XCTestCase {
             XCTAssert(finished, "set completed not in main queue")
         }
 
-        XCTAssertEqual(sut.size, UInt64(lengths.reduce(0, combine: +)))
+        XCTAssertEqual(sut.size, UInt64(lengths.reduce(0, +)))
     }
 
     // MARK: set
     
     func testSet_WithIdentityFormat_ExpectSyncSuccess() {
-        let sut = Cache<NSData>(name: self.name!)
-        let data = NSData.dataWithLength(5)
+        let sut = HanekeCache<Data>(name: self.name!)
+        let data = Data.dataWithLength(5)
         let key = self.name!
-        let expectation = self.expectationWithDescription(self.name!)
+        let expectation = self.expectation(description: self.name!)
         
         sut.set(value: data, key: key, success: {
             XCTAssertTrue($0 === data)
             expectation.fulfill()
         })
         
-        self.waitForExpectationsWithTimeout(0, handler: nil)
+        self.waitForExpectations(timeout: 0, handler: nil)
     }
     
     func testSet_WithCustomFormat_ExpectAsyncSuccess () {
-        let data = NSData.dataWithLength(6)
-        let expectedData = NSData.dataWithLength(7)
+        let data = Data.dataWithLength(6)
+        let expectedData = Data.dataWithLength(7)
         let key = self.name!
-        let format = Format<NSData>(name: self.name!, transform: { _ in return expectedData })
+        let format = Format<Data>(name: self.name!, transform: { _ in return expectedData })
         sut.addFormat(format)
-        let expectation = self.expectationWithDescription(self.name!)
+        let expectation = self.expectation(description: self.name!)
         
         var finished = false
         sut.set(value: data, key: key, formatName : format.name, success: {
@@ -152,7 +152,7 @@ class CacheTests: XCTestCase {
         })
         
         XCTAssertFalse(finished, "set completed in main queue")
-        self.waitForExpectationsWithTimeout(1, handler: nil)
+        self.waitForExpectations(timeout: 1, handler: nil)
     }
     
     func testSet_WithInexistingFormat () {
@@ -168,9 +168,9 @@ class CacheTests: XCTestCase {
     // MARK: fetch
     
     func testFetchOnSuccess_AfterSet_WithKey_ExpectSyncSuccess () {
-        let data = NSData.dataWithLength(8)
+        let data = Data.dataWithLength(8)
         let key = self.name!
-        let expectation = self.expectationWithDescription(key)
+        let expectation = self.expectation(description: key)
         sut.set(value: data, key: key)
 
         let fetch = sut.fetch(key: key).onSuccess {
@@ -180,31 +180,31 @@ class CacheTests: XCTestCase {
         
         XCTAssertTrue(fetch.hasSucceeded)
         XCTAssertFalse(fetch.hasFailed)
-        self.waitForExpectationsWithTimeout(0, handler: nil)
+        self.waitForExpectations(timeout: 0, handler: nil)
     }
     
     func testFetchOnFailure_WithKey_ExpectAsyncFailure () {
         let key = self.name!
-        let expectation = self.expectationWithDescription(key)
+        let expectation = self.expectation(description: key)
         
         let fetch = sut.fetch(key: key).onFailure { error in
             XCTAssertEqual(error!.domain, HanekeGlobals.Domain)
-            XCTAssertEqual(error!.code, HanekeGlobals.Cache.ErrorCode.ObjectNotFound.rawValue)
+            XCTAssertEqual(error!.code, HanekeGlobals.HanekeCache.ErrorCode.objectNotFound.rawValue)
             XCTAssertNotNil(error!.localizedDescription)
             expectation.fulfill()
         }
 
         XCTAssertFalse(fetch.hasSucceeded)
         XCTAssertFalse(fetch.hasFailed)
-        self.waitForExpectationsWithTimeout(1, handler: nil)
+        self.waitForExpectations(timeout: 1, handler: nil)
     }
     
-    func testFetch_AfterClearingMemoryCache_WithKey_ExpectAsyncSuccess () {
-        let data = NSData.dataWithLength(9)
+    func testFetch_AfterClearingMemoryHanekeCache_WithKey_ExpectAsyncSuccess () {
+        let data = Data.dataWithLength(9)
         let key = self.name!
-        let expectation = self.expectationWithDescription(key)
+        let expectation = self.expectation(description: key)
         sut.set(value: data, key: key)
-        self.clearMemoryCache()
+        self.clearMemoryHanekeCache()
         
         let fetch = sut.fetch(key: key, failure: { _ in
             XCTFail("expected success")
@@ -217,18 +217,18 @@ class CacheTests: XCTestCase {
         
         XCTAssertFalse(fetch.hasSucceeded)
         XCTAssertFalse(fetch.hasFailed)
-        self.waitForExpectationsWithTimeout(1, handler: nil)
+        self.waitForExpectations(timeout: 1, handler: nil)
         XCTAssertTrue(fetch.hasSucceeded)
         XCTAssertFalse(fetch.hasFailed)
     }
     
     func testFetch_WithKeyAndExistingFormat_ExpectAsyncFailure () {
         let key = self.name!
-        let expectation = self.expectationWithDescription(key)
+        let expectation = self.expectation(description: key)
         
         let fetch = sut.fetch(key: key, failure : { error in
             XCTAssertEqual(error!.domain, HanekeGlobals.Domain)
-            XCTAssertEqual(error!.code, HanekeGlobals.Cache.ErrorCode.ObjectNotFound.rawValue)
+            XCTAssertEqual(error!.code, HanekeGlobals.HanekeCache.ErrorCode.objectNotFound.rawValue)
             XCTAssertNotNil(error!.localizedDescription)
             expectation.fulfill()
         }) { _ in
@@ -238,18 +238,18 @@ class CacheTests: XCTestCase {
         
         XCTAssertFalse(fetch.hasSucceeded)
         XCTAssertFalse(fetch.hasFailed)
-        self.waitForExpectationsWithTimeout(1, handler: nil)
+        self.waitForExpectations(timeout: 1, handler: nil)
         XCTAssertFalse(fetch.hasSucceeded)
         XCTAssertTrue(fetch.hasFailed)
     }
     
     func testFetch_WithKeyAndInexistingFormat_ExpectSyncFailure () {
         let key = self.name!
-        let expectation = self.expectationWithDescription(key)
+        let expectation = self.expectation(description: key)
         
         let fetch = sut.fetch(key: key, formatName: key, failure : { error in
             XCTAssertEqual(error!.domain, HanekeGlobals.Domain)
-            XCTAssertEqual(error!.code, HanekeGlobals.Cache.ErrorCode.FormatNotFound.rawValue)
+            XCTAssertEqual(error!.code, HanekeGlobals.HanekeCache.ErrorCode.formatNotFound.rawValue)
             XCTAssertNotNil(error!.localizedDescription)
             expectation.fulfill()
         }) { _ in
@@ -259,17 +259,17 @@ class CacheTests: XCTestCase {
         
         XCTAssertFalse(fetch.hasSucceeded)
         XCTAssertTrue(fetch.hasFailed)
-        self.waitForExpectationsWithTimeout(0, handler: nil)
+        self.waitForExpectations(timeout: 0, handler: nil)
     }
     
-    func testFetch_AfterClearingMemoryCache_WithKeyAndFormatWithoutDiskCapacity_ExpectFailure() {
+    func testFetch_AfterClearingMemoryHanekeCache_WithKeyAndFormatWithoutDiskCapacity_ExpectFailure() {
         let key = self.name!
-        let data = NSData.dataWithLength(8)
-        let format = Format<NSData>(name: key, diskCapacity: 0)
+        let data = Data.dataWithLength(8)
+        let format = Format<Data>(name: key, diskCapacity: 0)
         sut.addFormat(format)
-        let expectation = self.expectationWithDescription("fetch image")
+        let expectation = self.expectation(description: "fetch image")
         sut.set(value: data, key: key, formatName: format.name)
-        self.clearMemoryCache()
+        self.clearMemoryHanekeCache()
         
         sut.fetch(key: key, formatName: format.name, failure: {_ in
             expectation.fulfill()
@@ -278,17 +278,17 @@ class CacheTests: XCTestCase {
                 expectation.fulfill()
         }
         
-        self.waitForExpectationsWithTimeout(1, handler: nil)
+        self.waitForExpectations(timeout: 1, handler: nil)
     }
     
-    func testFetch_AfterClearingMemoryCache_WithKeyAndFormatWithDiskCapacity_ExpectSuccess() {
+    func testFetch_AfterClearingMemoryHanekeCache_WithKeyAndFormatWithDiskCapacity_ExpectSuccess() {
         let key = self.name!
-        let data = NSData.dataWithLength(9)
-        let format = Format<NSData>(name: key)
+        let data = Data.dataWithLength(9)
+        let format = Format<Data>(name: key)
         sut.addFormat(format)
-        let expectation = self.expectationWithDescription(key)
+        let expectation = self.expectation(description: key)
         sut.set(value: data, key: key, formatName: format.name)
-        self.clearMemoryCache()
+        self.clearMemoryHanekeCache()
         
         self.sut.fetch(key: key, formatName: format.name, failure : { _ in
             XCTFail("expected success")
@@ -297,13 +297,13 @@ class CacheTests: XCTestCase {
                 expectation.fulfill()
         }
         
-        self.waitForExpectationsWithTimeout(1, handler: nil)
+        self.waitForExpectations(timeout: 1, handler: nil)
     }
     
     func testFetchOnSuccess_WithSyncFetcher_ExpectAsyncSuccess () {
-        let data = NSData.dataWithLength(10)
-        let fetcher = SimpleFetcher<NSData>(key: self.name!, value: data)
-        let expectation = self.expectationWithDescription(self.name!)
+        let data = Data.dataWithLength(10)
+        let fetcher = SimpleFetcher<Data>(key: self.name!, value: data)
+        let expectation = self.expectation(description: self.name!)
         
         let fetch = sut.fetch(fetcher: fetcher).onSuccess {
             XCTAssertTrue($0 === data)
@@ -312,16 +312,16 @@ class CacheTests: XCTestCase {
         
         XCTAssertFalse(fetch.hasSucceeded)
         XCTAssertFalse(fetch.hasFailed)
-        self.waitForExpectationsWithTimeout(1, handler: nil)
+        self.waitForExpectations(timeout: 1, handler: nil)
         XCTAssertTrue(fetch.hasSucceeded)
         XCTAssertFalse(fetch.hasFailed)
     }
     
     func testFetchOnFailure_WithSyncFailingFetcher_ExpectAsyncFailure() {
         
-        let fetcher = FailFetcher<NSData>(key: self.name!)
-        fetcher.error = NSError(domain: "test", code: 376, userInfo: nil)
-        let expectation = self.expectationWithDescription(self.name!)
+        let fetcher = FailFetcher<Data>(key: self.name!)
+        fetcher.error = Error(domain: "test", code: 376, userInfo: nil)
+        let expectation = self.expectation(description: self.name!)
         
         let fetch = sut.fetch(fetcher: fetcher).onFailure { error in
             XCTAssertEqual(error!, fetcher.error)
@@ -330,16 +330,16 @@ class CacheTests: XCTestCase {
         
         XCTAssertFalse(fetch.hasSucceeded)
         XCTAssertFalse(fetch.hasFailed)
-        self.waitForExpectationsWithTimeout(1, handler: nil)
+        self.waitForExpectations(timeout: 1, handler: nil)
         XCTAssertFalse(fetch.hasSucceeded)
         XCTAssertTrue(fetch.hasFailed)
     }
     
     func testFetch_AfterSet_WithFetcher_ExpectSyncSuccess () {
-        let data = NSData.dataWithLength(10)
+        let data = Data.dataWithLength(10)
         let key = self.name!
-        let fetcher = SimpleFetcher<NSData>(key: key, value: data)
-        let expectation = self.expectationWithDescription(key)
+        let fetcher = SimpleFetcher<Data>(key: key, value: data)
+        let expectation = self.expectation(description: key)
         sut.set(value: data, key: key)
         
         let fetch = sut.fetch(fetcher: fetcher, success: {
@@ -349,16 +349,16 @@ class CacheTests: XCTestCase {
         
         XCTAssertTrue(fetch.hasSucceeded)
         XCTAssertFalse(fetch.hasFailed)
-        self.waitForExpectationsWithTimeout(0, handler: nil)
+        self.waitForExpectations(timeout: 0, handler: nil)
     }
     
-    func testFetch_AfterSetAndClearingMemoryCache_WithFetcher_ExpectAsyncSuccess () {
-        let data = NSData.dataWithLength(10)
+    func testFetch_AfterSetAndClearingMemoryHanekeCache_WithFetcher_ExpectAsyncSuccess () {
+        let data = Data.dataWithLength(10)
         let key = self.name!
-        let fetcher = SimpleFetcher<NSData>(key: key, value: data)
-        let expectation = self.expectationWithDescription(key)
+        let fetcher = SimpleFetcher<Data>(key: key, value: data)
+        let expectation = self.expectation(description: key)
         sut.set(value: data, key: key)
-        self.clearMemoryCache()
+        self.clearMemoryHanekeCache()
         
         let fetch = sut.fetch(fetcher: fetcher, success: {
             XCTAssertTrue($0 !== data)
@@ -368,16 +368,16 @@ class CacheTests: XCTestCase {
         
         XCTAssertFalse(fetch.hasSucceeded)
         XCTAssertFalse(fetch.hasFailed)
-        self.waitForExpectationsWithTimeout(1, handler: nil)
+        self.waitForExpectations(timeout: 1, handler: nil)
         XCTAssertTrue(fetch.hasSucceeded)
         XCTAssertFalse(fetch.hasFailed)
     }
     
     func testFetch_WithSyncFetcher_ExpectAsyncSuccess () {
         let key = self.name!
-        let data = NSData.dataWithLength(11)
-        let fetcher = SimpleFetcher<NSData>(key: key, value: data)
-        let expectation = self.expectationWithDescription(key)
+        let data = Data.dataWithLength(11)
+        let fetcher = SimpleFetcher<Data>(key: key, value: data)
+        let expectation = self.expectation(description: key)
         
         let fetch = sut.fetch(fetcher: fetcher, failure : { _ in
             XCTFail("expected success")
@@ -389,21 +389,21 @@ class CacheTests: XCTestCase {
         
         XCTAssertFalse(fetch.hasSucceeded)
         XCTAssertFalse(fetch.hasFailed)
-        self.waitForExpectationsWithTimeout(1, handler: nil)
+        self.waitForExpectations(timeout: 1, handler: nil)
         XCTAssertTrue(fetch.hasSucceeded)
         XCTAssertFalse(fetch.hasFailed)
     }
     
     func testFetch_WithFetcherAndCustomFormat_ExpectAsyncSuccess () {
         let key = self.name!
-        let data = NSData.dataWithLength(12)
-        let formattedData = NSData.dataWithLength(13)
-        let fetcher = SimpleFetcher<NSData>(key: key, value: data)
-        let format = Format<NSData>(name: key, transform: { _ in
+        let data = Data.dataWithLength(12)
+        let formattedData = Data.dataWithLength(13)
+        let fetcher = SimpleFetcher<Data>(key: key, value: data)
+        let format = Format<Data>(name: key, transform: { _ in
             return formattedData
         })
         sut.addFormat(format)
-        let expectation = self.expectationWithDescription(key)
+        let expectation = self.expectation(description: key)
         
         let fetch = sut.fetch(fetcher: fetcher, formatName : format.name, failure : { _ in
             XCTFail("expected sucesss")
@@ -415,19 +415,19 @@ class CacheTests: XCTestCase {
         
         XCTAssertFalse(fetch.hasSucceeded)
         XCTAssertFalse(fetch.hasFailed)
-        self.waitForExpectationsWithTimeout(1, handler: nil)
+        self.waitForExpectations(timeout: 1, handler: nil)
         XCTAssertTrue(fetch.hasSucceeded)
         XCTAssertFalse(fetch.hasFailed)
     }
     
     func testFetch_WithFetcherAndInexistingFormat_ExpectSyncFailure () {
-        let expectation = self.expectationWithDescription(self.name!)
-        let data = NSData.dataWithLength(14)
-        let fetcher = SimpleFetcher<NSData>(key: self.name!, value: data)
+        let expectation = self.expectation(description: self.name!)
+        let data = Data.dataWithLength(14)
+        let fetcher = SimpleFetcher<Data>(key: self.name!, value: data)
 
         let fetch = sut.fetch(fetcher: fetcher, formatName: self.name!, failure : { error in
             XCTAssertEqual(error!.domain, HanekeGlobals.Domain)
-            XCTAssertEqual(error!.code, HanekeGlobals.Cache.ErrorCode.FormatNotFound.rawValue)
+            XCTAssertEqual(error!.code, HanekeGlobals.HanekeCache.ErrorCode.formatNotFound.rawValue)
             XCTAssertNotNil(error!.localizedDescription)
             expectation.fulfill()
         }) { _ in
@@ -437,15 +437,15 @@ class CacheTests: XCTestCase {
         
         XCTAssertFalse(fetch.hasSucceeded)
         XCTAssertTrue(fetch.hasFailed)
-        self.waitForExpectationsWithTimeout(0, handler: nil)
+        self.waitForExpectations(timeout: 0, handler: nil)
     }
     
     // MARK: remove
     
     func testRemove_WithExistingKey() {
         let key = self.name!
-        sut.set(value: NSData.dataWithLength(14), key: key)
-        let expectation = self.expectationWithDescription("fetch")
+        sut.set(value: Data.dataWithLength(14), key: key)
+        let expectation = self.expectation(description: "fetch")
 
         sut.remove(key: key)
         
@@ -455,15 +455,15 @@ class CacheTests: XCTestCase {
             XCTFail("expected failure")
             expectation.fulfill()
         }
-        self.waitForExpectationsWithTimeout(1, handler: nil)
+        self.waitForExpectations(timeout: 1, handler: nil)
     }
     
     func testRemove_WithExistingKeyInFormat() {
         let key = self.name!
-        let format = Format<NSData>(name: self.name!)
+        let format = Format<Data>(name: self.name!)
         sut.addFormat(format)
-        sut.set(value:  NSData.dataWithLength(15), key: key, formatName: format.name)
-        let expectation = self.expectationWithDescription("fetch")
+        sut.set(value:  Data.dataWithLength(15), key: key, formatName: format.name)
+        let expectation = self.expectation(description: "fetch")
         
         sut.remove(key: key, formatName: format.name)
         
@@ -473,15 +473,15 @@ class CacheTests: XCTestCase {
             XCTFail("expected failure")
             expectation.fulfill()
         }
-        self.waitForExpectationsWithTimeout(1, handler: nil)
+        self.waitForExpectations(timeout: 1, handler: nil)
     }
     
     func testRemove_WithExistingKeyInAnotherFormat() {
         let key = self.name!
-        let format = Format<NSData>(name: key)
+        let format = Format<Data>(name: key)
         sut.addFormat(format)
-        sut.set(value: NSData.dataWithLength(16), key: key)
-        let expectation = self.expectationWithDescription("fetch")
+        sut.set(value: Data.dataWithLength(16), key: key)
+        let expectation = self.expectation(description: "fetch")
         
         sut.remove(key: key, formatName: format.name)
         
@@ -491,13 +491,13 @@ class CacheTests: XCTestCase {
         }) { _ in
             expectation.fulfill()
         }
-        self.waitForExpectationsWithTimeout(1, handler: nil)
+        self.waitForExpectations(timeout: 1, handler: nil)
     }
     
     func testRemove_WithExistingKeyAndInexistingFormat() {
         let key = self.name!
-        sut.set(value: NSData.dataWithLength(17), key: key)
-        let expectation = self.expectationWithDescription("fetch")
+        sut.set(value: Data.dataWithLength(17), key: key)
+        let expectation = self.expectation(description: "fetch")
         
         sut.remove(key: key, formatName: key)
         
@@ -507,7 +507,7 @@ class CacheTests: XCTestCase {
         }) { _ in
             expectation.fulfill()
         }
-        self.waitForExpectationsWithTimeout(1, handler: nil)
+        self.waitForExpectations(timeout: 1, handler: nil)
     }
     
     func testRemove_WithInexistingKey() {
@@ -518,8 +518,8 @@ class CacheTests: XCTestCase {
     
     func testRemoveAll_AfterOne() {
         let key = self.name!
-        sut.set(value: NSData.dataWithLength(18), key: key)
-        let expectation = self.expectationWithDescription("fetch")
+        sut.set(value: Data.dataWithLength(18), key: key)
+        let expectation = self.expectation(description: "fetch")
         
         sut.removeAll()
         
@@ -529,13 +529,13 @@ class CacheTests: XCTestCase {
             XCTFail("expected failure")
             expectation.fulfill()
         }
-        self.waitForExpectationsWithTimeout(1, handler: nil)
+        self.waitForExpectations(timeout: 1, handler: nil)
     }
 
     func testRemoveAll_Completion() {
         let key = self.name!
-        sut.set(value: NSData.dataWithLength(18), key: key)
-        let expectation = self.expectationWithDescription("removeAll")
+        sut.set(value: Data.dataWithLength(18), key: key)
+        let expectation = self.expectation(description: "removeAll")
         var completed = false
         sut.removeAll {
             completed = true
@@ -543,22 +543,22 @@ class CacheTests: XCTestCase {
         }
 
         XCTAssertFalse(completed)
-        self.waitForExpectationsWithTimeout(1, handler: nil)
+        self.waitForExpectations(timeout: 1, handler: nil)
     }
 
-    func testRemoveAll_WhenDataAlreadyPresentInCachePath() {
-        let path = (sut.cachePath as NSString).stringByAppendingPathComponent("test")
-        let data = NSData.dataWithLength(1)
-        data.writeToFile(path, atomically: true)
-        XCTAssertTrue(NSFileManager.defaultManager().fileExistsAtPath(path))
+    func testRemoveAll_WhenDataAlreadyPresentInHanekeCachePath() {
+        let path = (sut.HanekeCachePath as NSString).appendingPathComponent("test")
+        let data = Data.dataWithLength(1)
+        try? data.write(to: URL(fileURLWithPath: path), options: [.atomic])
+        XCTAssertTrue(FileManager.default.fileExists(atPath: path))
 
-        let expectation = self.expectationWithDescription("removeAll")
+        let expectation = self.expectation(description: "removeAll")
         sut.removeAll {
             expectation.fulfill()
         }
 
-        self.waitForExpectationsWithTimeout(1, handler: nil)
-        XCTAssertFalse(NSFileManager.defaultManager().fileExistsAtPath(path))
+        self.waitForExpectations(timeout: 1, handler: nil)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: path))
     }
     
     func testRemoveAll_AfterNone() {
@@ -567,9 +567,9 @@ class CacheTests: XCTestCase {
     
     func testOnMemoryWarning() {
         let key = self.name!
-        let data = NSData.dataWithLength(18)
+        let data = Data.dataWithLength(18)
         sut.set(value: data, key: key)
-        let expectation = self.expectationWithDescription("fetch")
+        let expectation = self.expectation(description: "fetch")
 
         sut.onMemoryWarning()
         
@@ -580,34 +580,34 @@ class CacheTests: XCTestCase {
             expectation.fulfill()
         }
         XCTAssertFalse(fetch.hasSucceeded)
-        self.waitForExpectationsWithTimeout(1, handler: nil)
+        self.waitForExpectations(timeout: 1, handler: nil)
     }
     
     func testUIApplicationDidReceiveMemoryWarningNotification() {
-        let expectation = expectationWithDescription("onMemoryWarning")
+        let expectation = self.expectation(description: "onMemoryWarning")
         
-        let sut = CacheMock<UIImage>(name: self.name!)
+        let sut = HanekeCacheMock<UIImage>(name: self.name!)
         sut.expectation = expectation // XCode crashes if we use the original expectation directly
         
-        NSNotificationCenter.defaultCenter().postNotificationName(UIApplicationDidReceiveMemoryWarningNotification, object: nil)
+        NotificationCenter.default.post(name: NSNotification.Name.UIApplicationDidReceiveMemoryWarning, object: nil)
         
-        waitForExpectationsWithTimeout(0, handler: nil)
+        waitForExpectations(timeout: 0, handler: nil)
     }
     
     // MARK: Helpers
     
-    func clearMemoryCache() {
-        NSNotificationCenter.defaultCenter().postNotificationName(UIApplicationDidReceiveMemoryWarningNotification, object: nil)
+    func clearMemoryHanekeCache() {
+        NotificationCenter.default.post(name: NSNotification.Name.UIApplicationDidReceiveMemoryWarning, object: nil)
     }
 }
 
-class ImageCacheTests: XCTestCase {
+class ImageHanekeCacheTests: XCTestCase {
 
-    var sut : Cache<UIImage>!
+    var sut : HanekeCache<UIImage>!
     
     override func setUp() {
         super.setUp()
-        sut = Cache<UIImage>(name: self.name!)
+        sut = HanekeCache<UIImage>(name: self.name!)
     }
     
     override func tearDown() {
@@ -617,9 +617,9 @@ class ImageCacheTests: XCTestCase {
     
     func testSet_ExpectAsyncDecompressedImage() {
         let key = self.name!
-        sut = Cache<UIImage>(name: key)
-        let image = UIImage.imageWithColor(UIColor.greenColor())
-        let expectation = self.expectationWithDescription(key)
+        sut = HanekeCache<UIImage>(name: key)
+        let image = UIImage.imageWithColor(UIColor.green)
+        let expectation = self.expectation(description: key)
         
         var finished = false
         sut.set(value: image, key: key, success: {
@@ -630,13 +630,13 @@ class ImageCacheTests: XCTestCase {
         })
         
         XCTAssertFalse(finished, "set completed in main queue")
-        self.waitForExpectationsWithTimeout(1, handler: nil)
+        self.waitForExpectations(timeout: 1, handler: nil)
     }
     
     func testFetchOnSuccess_AfterSet_WithKey_ExpectSyncDecompressedImage () {
-        let image = UIImage.imageWithColor(UIColor.cyanColor())
+        let image = UIImage.imageWithColor(UIColor.cyan)
         let key = self.name!
-        let expectation = self.expectationWithDescription(key)
+        let expectation = self.expectation(description: key)
         sut.set(value: image, key: key, success: { decompressedImage in
             
             self.sut.fetch(key: key).onSuccess {
@@ -647,26 +647,26 @@ class ImageCacheTests: XCTestCase {
             
         })
         
-        self.waitForExpectationsWithTimeout(1, handler: nil)
+        self.waitForExpectations(timeout: 1, handler: nil)
     }
     
 }
 
 class FailFetcher<T : DataConvertible> : Fetcher<T> {
     
-    var error : NSError!
+    var error : Error!
     
     override init(key: String) {
         super.init(key: key)
     }
     
-    override func fetch(failure fail : ((NSError?) -> ()), success succeed : (T.Result) -> ()) {
+    override func fetch(failure fail : ((Error?) -> ()), success succeed : (T.Result) -> ()) {
         fail(error)
     }
     
 }
 
-class CacheMock<T : DataConvertible where T.Result == T, T : DataRepresentable> : Cache<T> {
+class HanekeCacheMock<T : DataConvertible> : HanekeCache<T> where T.Result == T, T : DataRepresentable {
     
     var expectation : XCTestExpectation?
     

--- a/HanekeTests/CacheTests.swift
+++ b/HanekeTests/CacheTests.swift
@@ -1,5 +1,5 @@
 //
-//  HanekeCacheTests.swift
+//  CacheTests.swift
 //  Haneke
 //
 //  Created by Luis Ascorbe on 23/07/14.
@@ -11,13 +11,13 @@ import UIKit
 import XCTest
 @testable import Haneke
 
-class HanekeCacheTests: XCTestCase {
+class CacheTests: XCTestCase {
     
-    var sut : HanekeCache<Data>!
+    var sut : Cache<Data>!
     
     override func setUp() {
         super.setUp()
-        sut = HanekeCache<Data>(name: self.name!)
+        sut = Cache<Data>(name: self.name!)
     }
     
     override func tearDown() {
@@ -33,7 +33,7 @@ class HanekeCacheTests: XCTestCase {
     
     func testInit() {
         let name = "name"
-        let sut = HanekeCache<Data>(name: name)
+        let sut = Cache<Data>(name: name)
         
         XCTAssertNotNil(sut.memoryWarningObserver)
         XCTAssertEqual(name, sut.name)
@@ -41,21 +41,21 @@ class HanekeCacheTests: XCTestCase {
     }
     
     func testDeinit() {
-        weak var _ = HanekeCache<UIImage>(name: self.name!)
+        weak var _ = Cache<UIImage>(name: self.name!)
     }
     
-    // MARK: HanekeCachePath
+    // MARK: CachePath
     
-    func testHanekeCachePath() {
-        let expectedHanekeCachePath = (DiskHanekeCache.basePath() as NSString).appendingPathComponent(sut.name)
-        XCTAssertEqual(sut.HanekeCachePath, expectedHanekeCachePath)
+    func testCachePath() {
+        let expectedCachePath = (DiskCache.basePath() as NSString).appendingPathComponent(sut.name)
+        XCTAssertEqual(sut.CachePath, expectedCachePath)
     }
     
     // MARK: formatPath
     
     func testFormatPath() {
         let formatName = self.name!
-        let expectedFormatPath = (sut.HanekeCachePath as NSString).appendingPathComponent(formatName)
+        let expectedFormatPath = (sut.CachePath as NSString).appendingPathComponent(formatName)
         
         let formatPath = sut.formatPath(formatName: formatName)
         
@@ -64,7 +64,7 @@ class HanekeCacheTests: XCTestCase {
     
     func testFormatPath_WithEmptyName() {
         let formatName = ""
-        let expectedFormatPath = (sut.HanekeCachePath as NSString).appendingPathComponent(formatName)
+        let expectedFormatPath = (sut.CachePath as NSString).appendingPathComponent(formatName)
         
         let formatPath = sut.formatPath(formatName: formatName)
         
@@ -123,7 +123,7 @@ class HanekeCacheTests: XCTestCase {
     // MARK: set
     
     func testSet_WithIdentityFormat_ExpectSyncSuccess() {
-        let sut = HanekeCache<Data>(name: self.name!)
+        let sut = Cache<Data>(name: self.name!)
         let data = Data.dataWithLength(5)
         let key = self.name!
         let expectation = self.expectation(description: self.name!)
@@ -189,7 +189,7 @@ class HanekeCacheTests: XCTestCase {
         
         let fetch = sut.fetch(key: key).onFailure { error in
             XCTAssertEqual(error!.domain, HanekeGlobals.Domain)
-            XCTAssertEqual(error!.code, HanekeGlobals.HanekeCache.ErrorCode.objectNotFound.rawValue)
+            XCTAssertEqual(error!.code, HanekeGlobals.Cache.ErrorCode.objectNotFound.rawValue)
             XCTAssertNotNil(error!.localizedDescription)
             expectation.fulfill()
         }
@@ -199,12 +199,12 @@ class HanekeCacheTests: XCTestCase {
         self.waitForExpectations(timeout: 1, handler: nil)
     }
     
-    func testFetch_AfterClearingMemoryHanekeCache_WithKey_ExpectAsyncSuccess () {
+    func testFetch_AfterClearingMemoryCache_WithKey_ExpectAsyncSuccess () {
         let data = Data.dataWithLength(9)
         let key = self.name!
         let expectation = self.expectation(description: key)
         sut.set(value: data, key: key)
-        self.clearMemoryHanekeCache()
+        self.clearMemoryCache()
         
         let fetch = sut.fetch(key: key, failure: { _ in
             XCTFail("expected success")
@@ -228,7 +228,7 @@ class HanekeCacheTests: XCTestCase {
         
         let fetch = sut.fetch(key: key, failure : { error in
             XCTAssertEqual(error!.domain, HanekeGlobals.Domain)
-            XCTAssertEqual(error!.code, HanekeGlobals.HanekeCache.ErrorCode.objectNotFound.rawValue)
+            XCTAssertEqual(error!.code, HanekeGlobals.Cache.ErrorCode.objectNotFound.rawValue)
             XCTAssertNotNil(error!.localizedDescription)
             expectation.fulfill()
         }) { _ in
@@ -249,7 +249,7 @@ class HanekeCacheTests: XCTestCase {
         
         let fetch = sut.fetch(key: key, formatName: key, failure : { error in
             XCTAssertEqual(error!.domain, HanekeGlobals.Domain)
-            XCTAssertEqual(error!.code, HanekeGlobals.HanekeCache.ErrorCode.formatNotFound.rawValue)
+            XCTAssertEqual(error!.code, HanekeGlobals.Cache.ErrorCode.formatNotFound.rawValue)
             XCTAssertNotNil(error!.localizedDescription)
             expectation.fulfill()
         }) { _ in
@@ -262,14 +262,14 @@ class HanekeCacheTests: XCTestCase {
         self.waitForExpectations(timeout: 0, handler: nil)
     }
     
-    func testFetch_AfterClearingMemoryHanekeCache_WithKeyAndFormatWithoutDiskCapacity_ExpectFailure() {
+    func testFetch_AfterClearingMemoryCache_WithKeyAndFormatWithoutDiskCapacity_ExpectFailure() {
         let key = self.name!
         let data = Data.dataWithLength(8)
         let format = Format<Data>(name: key, diskCapacity: 0)
         sut.addFormat(format)
         let expectation = self.expectation(description: "fetch image")
         sut.set(value: data, key: key, formatName: format.name)
-        self.clearMemoryHanekeCache()
+        self.clearMemoryCache()
         
         sut.fetch(key: key, formatName: format.name, failure: {_ in
             expectation.fulfill()
@@ -281,14 +281,14 @@ class HanekeCacheTests: XCTestCase {
         self.waitForExpectations(timeout: 1, handler: nil)
     }
     
-    func testFetch_AfterClearingMemoryHanekeCache_WithKeyAndFormatWithDiskCapacity_ExpectSuccess() {
+    func testFetch_AfterClearingMemoryCache_WithKeyAndFormatWithDiskCapacity_ExpectSuccess() {
         let key = self.name!
         let data = Data.dataWithLength(9)
         let format = Format<Data>(name: key)
         sut.addFormat(format)
         let expectation = self.expectation(description: key)
         sut.set(value: data, key: key, formatName: format.name)
-        self.clearMemoryHanekeCache()
+        self.clearMemoryCache()
         
         self.sut.fetch(key: key, formatName: format.name, failure : { _ in
             XCTFail("expected success")
@@ -352,13 +352,13 @@ class HanekeCacheTests: XCTestCase {
         self.waitForExpectations(timeout: 0, handler: nil)
     }
     
-    func testFetch_AfterSetAndClearingMemoryHanekeCache_WithFetcher_ExpectAsyncSuccess () {
+    func testFetch_AfterSetAndClearingMemoryCache_WithFetcher_ExpectAsyncSuccess () {
         let data = Data.dataWithLength(10)
         let key = self.name!
         let fetcher = SimpleFetcher<Data>(key: key, value: data)
         let expectation = self.expectation(description: key)
         sut.set(value: data, key: key)
-        self.clearMemoryHanekeCache()
+        self.clearMemoryCache()
         
         let fetch = sut.fetch(fetcher: fetcher, success: {
             XCTAssertTrue($0 !== data)
@@ -427,7 +427,7 @@ class HanekeCacheTests: XCTestCase {
 
         let fetch = sut.fetch(fetcher: fetcher, formatName: self.name!, failure : { error in
             XCTAssertEqual(error!.domain, HanekeGlobals.Domain)
-            XCTAssertEqual(error!.code, HanekeGlobals.HanekeCache.ErrorCode.formatNotFound.rawValue)
+            XCTAssertEqual(error!.code, HanekeGlobals.Cache.ErrorCode.formatNotFound.rawValue)
             XCTAssertNotNil(error!.localizedDescription)
             expectation.fulfill()
         }) { _ in
@@ -546,8 +546,8 @@ class HanekeCacheTests: XCTestCase {
         self.waitForExpectations(timeout: 1, handler: nil)
     }
 
-    func testRemoveAll_WhenDataAlreadyPresentInHanekeCachePath() {
-        let path = (sut.HanekeCachePath as NSString).appendingPathComponent("test")
+    func testRemoveAll_WhenDataAlreadyPresentInCachePath() {
+        let path = (sut.CachePath as NSString).appendingPathComponent("test")
         let data = Data.dataWithLength(1)
         try? data.write(to: URL(fileURLWithPath: path), options: [.atomic])
         XCTAssertTrue(FileManager.default.fileExists(atPath: path))
@@ -586,7 +586,7 @@ class HanekeCacheTests: XCTestCase {
     func testUIApplicationDidReceiveMemoryWarningNotification() {
         let expectation = self.expectation(description: "onMemoryWarning")
         
-        let sut = HanekeCacheMock<UIImage>(name: self.name!)
+        let sut = CacheMock<UIImage>(name: self.name!)
         sut.expectation = expectation // XCode crashes if we use the original expectation directly
         
         NotificationCenter.default.post(name: NSNotification.Name.UIApplicationDidReceiveMemoryWarning, object: nil)
@@ -596,18 +596,18 @@ class HanekeCacheTests: XCTestCase {
     
     // MARK: Helpers
     
-    func clearMemoryHanekeCache() {
+    func clearMemoryCache() {
         NotificationCenter.default.post(name: NSNotification.Name.UIApplicationDidReceiveMemoryWarning, object: nil)
     }
 }
 
-class ImageHanekeCacheTests: XCTestCase {
+class ImageCacheTests: XCTestCase {
 
-    var sut : HanekeCache<UIImage>!
+    var sut : Cache<UIImage>!
     
     override func setUp() {
         super.setUp()
-        sut = HanekeCache<UIImage>(name: self.name!)
+        sut = Cache<UIImage>(name: self.name!)
     }
     
     override func tearDown() {
@@ -617,7 +617,7 @@ class ImageHanekeCacheTests: XCTestCase {
     
     func testSet_ExpectAsyncDecompressedImage() {
         let key = self.name!
-        sut = HanekeCache<UIImage>(name: key)
+        sut = Cache<UIImage>(name: key)
         let image = UIImage.imageWithColor(UIColor.green)
         let expectation = self.expectation(description: key)
         
@@ -666,7 +666,7 @@ class FailFetcher<T : DataConvertible> : Fetcher<T> {
     
 }
 
-class HanekeCacheMock<T : DataConvertible> : HanekeCache<T> where T.Result == T, T : DataRepresentable {
+class CacheMock<T : DataConvertible> : Cache<T> where T.Result == T, T : DataRepresentable {
     
     var expectation : XCTestExpectation?
     

--- a/HanekeTests/DataTests.swift
+++ b/HanekeTests/DataTests.swift
@@ -36,7 +36,7 @@ class StringDataTests: XCTestCase {
     
     func testConvertFromData() {
         let string = self.name!
-        let data = string.dataUsingEncoding(NSUTF8StringEncoding)!
+        let data = string.data(using: String.Encoding.utf8)!
         
         let result = String.convertFromData(data)
         
@@ -45,7 +45,7 @@ class StringDataTests: XCTestCase {
     
     func testAsData() {
         let string = self.name!
-        let data = string.dataUsingEncoding(NSUTF8StringEncoding)!
+        let data = string.data(using: String.Encoding.utf8)!
         
         let result = string.asData()
         
@@ -57,15 +57,15 @@ class StringDataTests: XCTestCase {
 class DataDataTests: XCTestCase {
     
     func testConvertFromData() {
-        let data = NSData.dataWithLength(32)
+        let data = Data.dataWithLength(32)
         
-        let result = NSData.convertFromData(data)
+        let result = Data.convertFromData(data)
         
         XCTAssertEqual(result!, data)
     }
     
     func testAsData() {
-        let data = NSData.dataWithLength(32)
+        let data = Data.dataWithLength(32)
         
         let result = data.asData()
         
@@ -78,7 +78,7 @@ class JSONDataTests: XCTestCase {
     
     func testConvertFromData_WithArrayData() {
         let json = [self.name!]
-        let data = try! NSJSONSerialization.dataWithJSONObject(json, options: NSJSONWritingOptions())
+        let data = try! JSONSerialization.data(withJSONObject: json, options: JSONSerialization.WritingOptions())
         
         let result = JSON.convertFromData(data)!
         
@@ -86,27 +86,27 @@ class JSONDataTests: XCTestCase {
         case .Dictionary(_):
             XCTFail("expected array")
         case .Array(let object):
-            let resultData = try! NSJSONSerialization.dataWithJSONObject(object, options: NSJSONWritingOptions())
+            let resultData = try! JSONSerialization.data(withJSONObject: object, options: JSONSerialization.WritingOptions())
             XCTAssertEqual(resultData, data)
         }
     }
     
     func testConvertFromData_WithDictionaryData() {
         let json = ["test": self.name!]
-        let data = try! NSJSONSerialization.dataWithJSONObject(json, options: NSJSONWritingOptions())
+        let data = try! JSONSerialization.data(withJSONObject: json, options: JSONSerialization.WritingOptions())
         
         let result = JSON.convertFromData(data)!
         
         switch result {
         case .Dictionary(let object):
-            try! NSJSONSerialization.dataWithJSONObject(object, options: NSJSONWritingOptions())
+            try! JSONSerialization.data(withJSONObject: object, options: JSONSerialization.WritingOptions())
         case .Array(_):
             XCTFail("expected dictionary")
         }
     }
 
     func testConvertFromData_WithInvalidData() {
-        let data = NSData.dataWithLength(100)
+        let data = Data.dataWithLength(100)
 
         let result = JSON.convertFromData(data)
         
@@ -119,7 +119,7 @@ class JSONDataTests: XCTestCase {
         
         let result = json.asData()
         
-        let data = try! NSJSONSerialization.dataWithJSONObject(object, options: NSJSONWritingOptions())
+        let data = try! JSONSerialization.data(withJSONObject: object, options: JSONSerialization.WritingOptions())
         XCTAssertEqual(result, data)
     }
     
@@ -129,7 +129,7 @@ class JSONDataTests: XCTestCase {
         
         let result = json.asData()
         
-        let data = try! NSJSONSerialization.dataWithJSONObject(object, options: NSJSONWritingOptions())
+        let data = try! JSONSerialization.data(withJSONObject: object, options: JSONSerialization.WritingOptions())
         XCTAssertEqual(result, data)
     }
     

--- a/HanekeTests/DiskFetcherTests.swift
+++ b/HanekeTests/DiskFetcherTests.swift
@@ -30,11 +30,11 @@ class DiskFetcherTests: DiskTestCase {
     }
     
     func testFetchImage_Success() {
-        let image = UIImage.imageWithColor(UIColor.greenColor(), CGSizeMake(10, 20))
+        let image = UIImage.imageWithColor(UIColor.green, CGSize(width: 10, height: 20))
         let data = UIImagePNGRepresentation(image)!
-        data.writeToFile(sut.path, atomically: true)
+        try? data.write(to: URL(fileURLWithPath: sut.path), options: [.atomic])
         
-        let expectation = self.expectationWithDescription(self.name!)
+        let expectation = self.expectation(description: self.name!)
         
         sut.fetch(failure: { _ in
             XCTFail("Expected to succeed")
@@ -45,11 +45,11 @@ class DiskFetcherTests: DiskTestCase {
             expectation.fulfill()
         }
         
-        self.waitForExpectationsWithTimeout(1, handler: nil)
+        self.waitForExpectations(timeout: 1, handler: nil)
     }
     
     func testFetchImage_Failure_NSFileReadNoSuchFileError() {
-        let expectation = self.expectationWithDescription(self.name!)
+        let expectation = self.expectation(description: self.name!)
         
         sut.fetch(failure: {
             XCTAssertEqual($0!.code, NSFileReadNoSuchFileError)
@@ -60,18 +60,18 @@ class DiskFetcherTests: DiskTestCase {
             expectation.fulfill()
         }
         
-        self.waitForExpectationsWithTimeout(1, handler: nil)
+        self.waitForExpectations(timeout: 1, handler: nil)
     }
     
     func testFetchImage_Failure_HNKDiskEntityInvalidDataError() {
-        let data = NSData()
-        data.writeToFile(sut.path, atomically: true)
+        let data = Data()
+        try? data.write(to: URL(fileURLWithPath: sut.path), options: [.atomic])
         
-        let expectation = self.expectationWithDescription(self.name!)
+        let expectation = self.expectation(description: self.name!)
         
         sut.fetch(failure: {
             XCTAssertEqual($0!.domain, HanekeGlobals.Domain)
-            XCTAssertEqual($0!.code, HanekeGlobals.DiskFetcher.ErrorCode.InvalidData.rawValue)
+            XCTAssertEqual($0!.code, HanekeGlobals.DiskFetcher.ErrorCode.invalidData.rawValue)
             XCTAssertNotNil($0!.localizedDescription)
             expectation.fulfill()
         }) { _ in
@@ -79,13 +79,13 @@ class DiskFetcherTests: DiskTestCase {
             expectation.fulfill()
         }
         
-        self.waitForExpectationsWithTimeout(1, handler: nil)
+        self.waitForExpectations(timeout: 1, handler: nil)
     }
 
     func testCancelFetch() {
-        let image = UIImage.imageWithColor(UIColor.greenColor())
+        let image = UIImage.imageWithColor(UIColor.green)
         let data = UIImagePNGRepresentation(image)!
-        data.writeToFile(directoryPath, atomically: true)
+        try? data.write(to: URL(fileURLWithPath: directoryPath), options: [.atomic])
         sut.fetch(failure: { error in
             XCTFail("Unexpected failure with error \(error)")
         }) { _ in
@@ -104,10 +104,10 @@ class DiskFetcherTests: DiskTestCase {
     // MARK: Cache extension
     
     func testCacheFetch_Success() {
-        let data = NSData.dataWithLength(1)
+        let data = Data.dataWithLength(1)
         let path = self.writeData(data)
-        let expectation = self.expectationWithDescription(self.name!)
-        let cache = Cache<NSData>(name: self.name!)
+        let expectation = self.expectation(description: self.name!)
+        let cache = Cache<Data>(name: self.name!)
         
         cache.fetch(path: path, failure: {_ in
             XCTFail("expected success")
@@ -117,15 +117,15 @@ class DiskFetcherTests: DiskTestCase {
             expectation.fulfill()
         }
         
-        self.waitForExpectationsWithTimeout(1, handler: nil)
+        self.waitForExpectations(timeout: 1, handler: nil)
         
         cache.removeAll()
     }
     
     func testCacheFetch_Failure() {
-        let path = (self.directoryPath as NSString).stringByAppendingPathComponent(self.name!)
-        let expectation = self.expectationWithDescription(self.name!)
-        let cache = Cache<NSData>(name: self.name!)
+        let path = (self.directoryPath as NSString).appendingPathComponent(self.name!)
+        let expectation = self.expectation(description: self.name!)
+        let cache = Cache<Data>(name: self.name!)
         
         cache.fetch(path: path, failure: {_ in
             expectation.fulfill()
@@ -134,17 +134,17 @@ class DiskFetcherTests: DiskTestCase {
             expectation.fulfill()
         }
         
-        self.waitForExpectationsWithTimeout(1, handler: nil)
+        self.waitForExpectations(timeout: 1, handler: nil)
         
         cache.removeAll()
     }
     
     func testCacheFetch_WithFormat() {
-        let data = NSData.dataWithLength(1)
+        let data = Data.dataWithLength(1)
         let path = self.writeData(data)
-        let expectation = self.expectationWithDescription(self.name!)
-        let cache = Cache<NSData>(name: self.name!)
-        let format = Format<NSData>(name: self.name!)
+        let expectation = self.expectation(description: self.name!)
+        let cache = Cache<Data>(name: self.name!)
+        let format = Format<Data>(name: self.name!)
         cache.addFormat(format)
         
         cache.fetch(path: path, formatName: format.name, failure: {_ in
@@ -155,7 +155,7 @@ class DiskFetcherTests: DiskTestCase {
             expectation.fulfill()
         }
         
-        self.waitForExpectationsWithTimeout(1, handler: nil)
+        self.waitForExpectations(timeout: 1, handler: nil)
         
         cache.removeAll()
     }

--- a/HanekeTests/DiskTestCase.swift
+++ b/HanekeTests/DiskTestCase.swift
@@ -11,36 +11,36 @@ import XCTest
 class DiskTestCase : XCTestCase {
  
     lazy var directoryPath: String = {
-        let documentsPath = NSSearchPathForDirectoriesInDomains(NSSearchPathDirectory.DocumentDirectory, NSSearchPathDomainMask.UserDomainMask, true)[0]
-        let directoryPath = (documentsPath as NSString).stringByAppendingPathComponent(self.name!)
+        let documentsPath = NSSearchPathForDirectoriesInDomains(FileManager.SearchPathDirectory.documentDirectory, FileManager.SearchPathDomainMask.userDomainMask, true)[0]
+        let directoryPath = (documentsPath as NSString).appendingPathComponent(self.name!)
         return directoryPath
     }()
     
     override func setUp() {
         super.setUp()
-        try! NSFileManager.defaultManager().createDirectoryAtPath(directoryPath, withIntermediateDirectories: true, attributes: nil)
+        try! FileManager.default.createDirectory(atPath: directoryPath, withIntermediateDirectories: true, attributes: nil)
     }
     
     override func tearDown() {
-        try! NSFileManager.defaultManager().removeItemAtPath(directoryPath)
+        try! FileManager.default.removeItem(atPath: directoryPath)
         super.tearDown()
     }
     
     var dataIndex = 0
     
-    func writeDataWithLength(length : Int) -> String {
-        let data = NSData.dataWithLength(length)
+    func writeDataWithLength(_ length : Int) -> String {
+        let data = Data.dataWithLength(length)
         return self.writeData(data)
     }
     
-    func writeData(data : NSData) -> String {
+    func writeData(_ data : Data) -> String {
         let path = self.uniquePath()
-        data.writeToFile(path, atomically: true)
+        try? data.write(to: URL(fileURLWithPath: path), options: [.atomic])
         return path
     }
     
     func uniquePath() -> String {
-        let path = (self.directoryPath as NSString).stringByAppendingPathComponent("\(dataIndex)")
+        let path = (self.directoryPath as NSString).appendingPathComponent("\(dataIndex)")
         dataIndex += 1
         return path
     }

--- a/HanekeTests/FetchTests.swift
+++ b/HanekeTests/FetchTests.swift
@@ -57,7 +57,7 @@ class FetchTests : XCTestCase {
 
     func testSucceed_AfterOnSuccess() {
         let value = self.name!
-        let expectation = self.expectationWithDescription(value)
+        let expectation = self.expectation(description: value)
         sut.onSuccess {
             XCTAssertEqual($0, value)
             expectation.fulfill()
@@ -65,7 +65,7 @@ class FetchTests : XCTestCase {
         
         sut.succeed(value)
         
-        self.waitForExpectationsWithTimeout(0, handler: nil)
+        self.waitForExpectations(timeout: 0, handler: nil)
     }
     
     func testFail() {
@@ -73,8 +73,8 @@ class FetchTests : XCTestCase {
     }
     
     func testFail_AfterOnFailure() {
-        let error = NSError(domain: self.name!, code: 10, userInfo: nil)
-        let expectation = self.expectationWithDescription(self.name!)
+        let error = Error(domain: self.name!, code: 10, userInfo: nil)
+        let expectation = self.expectation(description: self.name!)
         sut.onFailure {
             XCTAssertEqual($0!, error)
             expectation.fulfill()
@@ -82,7 +82,7 @@ class FetchTests : XCTestCase {
         
         sut.fail(error)
         
-        self.waitForExpectationsWithTimeout(0, handler: nil)
+        self.waitForExpectations(timeout: 0, handler: nil)
     }
     
     func testOnSuccess() {
@@ -94,14 +94,14 @@ class FetchTests : XCTestCase {
     func testOnSuccess_AfterSucceed() {
         let value = self.name!
         sut.succeed(value)
-        let expectation = self.expectationWithDescription(value)
+        let expectation = self.expectation(description: value)
         
         sut.onSuccess {
             XCTAssertEqual($0, value)
             expectation.fulfill()
         }
         
-        self.waitForExpectationsWithTimeout(0, handler: nil)
+        self.waitForExpectations(timeout: 0, handler: nil)
     }
     
     func testOnFailure() {
@@ -111,16 +111,16 @@ class FetchTests : XCTestCase {
     }
     
     func testOnFailure_AfterFail() {
-        let error = NSError(domain: self.name!, code: 10, userInfo: nil)
+        let error = Error(domain: self.name!, code: 10, userInfo: nil)
         sut.fail(error)
-        let expectation = self.expectationWithDescription(self.name!)
+        let expectation = self.expectation(description: self.name!)
         
         sut.onFailure {
             XCTAssertEqual($0!, error)
             expectation.fulfill()
         }
         
-        self.waitForExpectationsWithTimeout(0, handler: nil)
+        self.waitForExpectations(timeout: 0, handler: nil)
     }
     
 }

--- a/HanekeTests/FetcherTests.swift
+++ b/HanekeTests/FetcherTests.swift
@@ -14,7 +14,7 @@ class FetcherTests: XCTestCase {
     
     func testSimpleFetcherInit() {
         let key = self.name!
-        let image = UIImage.imageWithColor(UIColor.greenColor())
+        let image = UIImage.imageWithColor(UIColor.green)
         
         let fetcher = SimpleFetcher<UIImage>(key: key, value: image)
 
@@ -24,9 +24,9 @@ class FetcherTests: XCTestCase {
     
     func testSimpleFetcherFetch() {
         let key = self.name!
-        let image = UIImage.imageWithColor(UIColor.greenColor())
+        let image = UIImage.imageWithColor(UIColor.green)
         let fetcher = SimpleFetcher<UIImage>(key: key, value: image)
-        let expectation = self.expectationWithDescription(key)
+        let expectation = self.expectation(description: key)
         
         fetcher.fetch(failure: { _ in
             XCTFail("expected success")
@@ -35,29 +35,29 @@ class FetcherTests: XCTestCase {
             expectation.fulfill()
         }
         
-        self.waitForExpectationsWithTimeout(0, handler: nil)
+        self.waitForExpectations(timeout: 0, handler: nil)
     }
     
     func testCacheFetch() {
-        let data = NSData.dataWithLength(1)
-        let expectation = self.expectationWithDescription(self.name!)
-        let cache = Cache<NSData>(name: self.name!)
+        let data = Data.dataWithLength(1)
+        let expectation = self.expectation(description: self.name!)
+        let cache = Cache<Data>(name: self.name!)
         
         cache.fetch(key: self.name!, value: data) {
             XCTAssertEqual($0, data)
             expectation.fulfill()
         }
         
-        self.waitForExpectationsWithTimeout(1, handler: nil)
+        self.waitForExpectations(timeout: 1, handler: nil)
         
         cache.removeAll()
     }
     
     func testCacheFetch_WithFormat() {
-        let data = NSData.dataWithLength(1)
-        let expectation = self.expectationWithDescription(self.name!)
-        let cache = Cache<NSData>(name: self.name!)
-        let format = Format<NSData>(name: self.name!)
+        let data = Data.dataWithLength(1)
+        let expectation = self.expectation(description: self.name!)
+        let cache = Cache<Data>(name: self.name!)
+        let format = Format<Data>(name: self.name!)
         cache.addFormat(format)
         
         cache.fetch(key: self.name!, value: data, formatName: format.name) {
@@ -65,7 +65,7 @@ class FetcherTests: XCTestCase {
             expectation.fulfill()
         }
         
-        self.waitForExpectationsWithTimeout(1, handler: nil)
+        self.waitForExpectations(timeout: 1, handler: nil)
         
         cache.removeAll()
     }

--- a/HanekeTests/FormatTests.swift
+++ b/HanekeTests/FormatTests.swift
@@ -35,8 +35,8 @@ class FormatTests: XCTestCase {
     
     func testResizeImageScaleNone() {
         
-        let originalImage = UIImage.imageWithColor(UIColor.redColor(), CGSize(width: 1, height: 1), false)
-        let sut = ImageResizer(size: CGSizeMake(30, 5), scaleMode: .None)
+        let originalImage = UIImage.imageWithColor(UIColor.red, false, CGSize(width: 1, height: 1))
+        let sut = ImageResizer(size: CGSize(width: 30, height: 5), scaleMode: .None)
         let resizedImage = sut.resizeImage(originalImage)
         
         XCTAssertEqual(originalImage.size.width, resizedImage.size.width)
@@ -47,8 +47,8 @@ class FormatTests: XCTestCase {
     
     func testResizeImageScaleFill() {
         
-        let originalImage = UIImage.imageWithColor(UIColor.redColor(), CGSize(width: 1, height: 1), false)
-        let sut = ImageResizer(size: CGSizeMake(30, 5), scaleMode : .Fill)
+        let originalImage = UIImage.imageWithColor(UIColor.red, false, CGSize(width: 1, height: 1))
+        let sut = ImageResizer(size: CGSize(width: 30, height: 5), scaleMode : .Fill)
         let resizedImage = sut.resizeImage(originalImage)
         
         XCTAssertNotEqual(originalImage.size.width, resizedImage.size.width)
@@ -59,8 +59,8 @@ class FormatTests: XCTestCase {
     
     func testResizeImageScaleAspectFill() {
         
-        let originalImage = UIImage.imageWithColor(UIColor.redColor(), CGSize(width: 1, height: 1), false)
-        let sut = ImageResizer(size: CGSizeMake(30, 5), scaleMode: .AspectFill)
+        let originalImage = UIImage.imageWithColor(UIColor.red, false, CGSize(width: 1, height: 1))
+        let sut = ImageResizer(size: CGSize(width: 30, height: 5), scaleMode: .AspectFill)
         let resizedImage = sut.resizeImage(originalImage)
         
         XCTAssertNotEqual(originalImage.size.width, resizedImage.size.width)
@@ -71,8 +71,8 @@ class FormatTests: XCTestCase {
     
     func testResizeImageScaleAspectFit() {
         
-        let originalImage = UIImage.imageWithColor(UIColor.redColor(), CGSize(width: 1, height: 1), false)
-        let sut = ImageResizer(size: CGSizeMake(30, 5), scaleMode: .AspectFit)
+        let originalImage = UIImage.imageWithColor(UIColor.red, false, CGSize(width: 1, height: 1))
+        let sut = ImageResizer(size: CGSize(width: 30, height: 5), scaleMode: .AspectFit)
         let resizedImage = sut.resizeImage(originalImage)
         
         XCTAssertNotEqual(originalImage.size.width, resizedImage.size.width)
@@ -83,8 +83,8 @@ class FormatTests: XCTestCase {
     
     func testResizeImageScaleAspectFillWithoutUpscaling() {
         
-        let originalImage = UIImage.imageWithColor(UIColor.redColor(), CGSize(width: 1, height: 1), false)
-        let sut = ImageResizer(size: CGSizeMake(30, 5), scaleMode: .AspectFill, allowUpscaling: false)
+        let originalImage = UIImage.imageWithColor(UIColor.red, false, CGSize(width: 1, height: 1))
+        let sut = ImageResizer(size: CGSize(width: 30, height: 5), scaleMode: .AspectFill, allowUpscaling: false)
         let resizedImage = sut.resizeImage(originalImage)
         
         XCTAssertEqual(originalImage.size.width, resizedImage.size.width)

--- a/HanekeTests/NSData+Test.swift
+++ b/HanekeTests/NSData+Test.swift
@@ -8,11 +8,11 @@
 
 import Foundation
 
-extension NSData {
+extension Data {
     
-    class func dataWithLength(length : Int) -> NSData {
-        var buffer: [UInt8] = [UInt8](count:length, repeatedValue:0)
-        return NSData(bytes:&buffer, length: length)
+    static func dataWithLength(_ length : Int) -> Data {
+        var buffer: [UInt8] = [UInt8](repeating: 0, count: length)
+        return Data(bytes: UnsafePointer<UInt8>(&buffer), count: length)
     }
     
 }

--- a/HanekeTests/NSFileManager+HanekeTests.swift
+++ b/HanekeTests/NSFileManager+HanekeTests.swift
@@ -36,8 +36,8 @@ class NSFileManager_HanekeTests: DiskTestCase {
         let sut = FileManager.default
     
         let paths = [self.writeDataWithLength(1), self.writeDataWithLength(2)].sorted(by: <)
-        var resultPaths : Array<String> = []
-        var indexes : Array<Int> = []
+        var resultPaths : [String] = []
+        var indexes : [Int] = []
         
         sut.enumerateContentsOfDirectoryAtPath(self.directoryPath, orderedByProperty: URLResourceKey.nameKey, ascending: true) { (URL : Foundation.URL, index : Int, _) -> Void in
             resultPaths.append(URL.path!)
@@ -54,8 +54,8 @@ class NSFileManager_HanekeTests: DiskTestCase {
         let sut = FileManager.default
         
         let paths = [self.writeDataWithLength(1), self.writeDataWithLength(2)].sorted(by: >)
-        var resultPaths : Array<String> = []
-        var indexes : Array<Int> = []
+        var resultPaths : [String] = []
+        var indexes : [Int] = []
         
         sut.enumerateContentsOfDirectoryAtPath(self.directoryPath, orderedByProperty: URLResourceKey.nameKey, ascending: false) { (URL : Foundation.URL, index : Int, _) -> Void in
             resultPaths.append(URL.path!)
@@ -72,7 +72,7 @@ class NSFileManager_HanekeTests: DiskTestCase {
         let sut = FileManager.default
         
         let paths = [self.writeDataWithLength(1), self.writeDataWithLength(2)]
-        var resultPaths : Array<String> = []
+        var resultPaths : [String] = []
         
         sut.enumerateContentsOfDirectoryAtPath(self.directoryPath, orderedByProperty: URLResourceKey.fileSizeKey, ascending: true) { (URL : Foundation.URL, index : Int, _) -> Void in
             resultPaths.append(URL.path!)
@@ -102,7 +102,7 @@ class NSFileManager_HanekeTests: DiskTestCase {
         let paths = [self.writeDataWithLength(1), self.writeDataWithLength(2)]
         try! sut.setAttributes([FileAttributeKey.modificationDate : Date.distantPast], ofItemAtPath: paths[0])
         
-        var resultPaths : Array<String> = []
+        var resultPaths : [String] = []
         
         sut.enumerateContentsOfDirectoryAtPath(self.directoryPath, orderedByProperty: URLResourceKey.contentModificationDateKey, ascending: true) { (URL : Foundation.URL, index : Int, _) -> Void in
             resultPaths.append(URL.path!)
@@ -117,7 +117,7 @@ class NSFileManager_HanekeTests: DiskTestCase {
         
         let paths = [self.writeDataWithLength(1), self.writeDataWithLength(2)]
         try! sut.setAttributes([FileAttributeKey.modificationDate : Date.distantPast], ofItemAtPath: paths[1])
-        var resultPaths : Array<String> = []
+        var resultPaths : [String] = []
         
         sut.enumerateContentsOfDirectoryAtPath(self.directoryPath, orderedByProperty: URLResourceKey.contentModificationDateKey, ascending: false) { (URL : Foundation.URL, index : Int, _) -> Void in
             resultPaths.append(URL.path!)

--- a/HanekeTests/NSFileManager+HanekeTests.swift
+++ b/HanekeTests/NSFileManager+HanekeTests.swift
@@ -12,19 +12,19 @@ import XCTest
 class NSFileManager_HanekeTests: DiskTestCase {
     
     func testEnumerateContentsOfDirectoryAtPathEmpty() {
-        let sut = NSFileManager.defaultManager()
+        let sut = FileManager.default
         
-        sut.enumerateContentsOfDirectoryAtPath(self.directoryPath, orderedByProperty: NSURLNameKey, ascending: true) { (URL : NSURL, index : Int, _) -> Void in
+        sut.enumerateContentsOfDirectoryAtPath(self.directoryPath, orderedByProperty: URLResourceKey.nameKey, ascending: true) { (URL : Foundation.URL, index : Int, _) -> Void in
             XCTFail()
         }
     }
     
     func testEnumerateContentsOfDirectoryAtPathStop() {
-        let sut = NSFileManager.defaultManager()
+        let sut = FileManager.default
         [self.writeDataWithLength(1), self.writeDataWithLength(2)]
         var count = 0
         
-        sut.enumerateContentsOfDirectoryAtPath(self.directoryPath, orderedByProperty: NSURLNameKey, ascending: true) { (_ : NSURL, index : Int, inout stop : Bool) -> Void in
+        sut.enumerateContentsOfDirectoryAtPath(self.directoryPath, orderedByProperty: URLResourceKey.nameKey, ascending: true) { (_ : URL, index : Int, stop : inout Bool) -> Void in
             count += 1
             stop = true
         }
@@ -33,13 +33,13 @@ class NSFileManager_HanekeTests: DiskTestCase {
     }
     
     func testEnumerateContentsOfDirectoryAtPathNameAscending() {
-        let sut = NSFileManager.defaultManager()
+        let sut = FileManager.default
     
-        let paths = [self.writeDataWithLength(1), self.writeDataWithLength(2)].sort(<)
+        let paths = [self.writeDataWithLength(1), self.writeDataWithLength(2)].sorted(by: <)
         var resultPaths : Array<String> = []
         var indexes : Array<Int> = []
         
-        sut.enumerateContentsOfDirectoryAtPath(self.directoryPath, orderedByProperty: NSURLNameKey, ascending: true) { (URL : NSURL, index : Int, _) -> Void in
+        sut.enumerateContentsOfDirectoryAtPath(self.directoryPath, orderedByProperty: URLResourceKey.nameKey, ascending: true) { (URL : Foundation.URL, index : Int, _) -> Void in
             resultPaths.append(URL.path!)
             indexes.append(index)
         }
@@ -51,13 +51,13 @@ class NSFileManager_HanekeTests: DiskTestCase {
     }
     
     func testEnumerateContentsOfDirectoryAtPathNameDescending() {
-        let sut = NSFileManager.defaultManager()
+        let sut = FileManager.default
         
-        let paths = [self.writeDataWithLength(1), self.writeDataWithLength(2)].sort(>)
+        let paths = [self.writeDataWithLength(1), self.writeDataWithLength(2)].sorted(by: >)
         var resultPaths : Array<String> = []
         var indexes : Array<Int> = []
         
-        sut.enumerateContentsOfDirectoryAtPath(self.directoryPath, orderedByProperty: NSURLNameKey, ascending: false) { (URL : NSURL, index : Int, _) -> Void in
+        sut.enumerateContentsOfDirectoryAtPath(self.directoryPath, orderedByProperty: URLResourceKey.nameKey, ascending: false) { (URL : Foundation.URL, index : Int, _) -> Void in
             resultPaths.append(URL.path!)
             indexes.append(index)
         }
@@ -69,12 +69,12 @@ class NSFileManager_HanekeTests: DiskTestCase {
     }
     
     func testEnumerateContentsOfDirectoryAtPathFileSizeAscending() {
-        let sut = NSFileManager.defaultManager()
+        let sut = FileManager.default
         
         let paths = [self.writeDataWithLength(1), self.writeDataWithLength(2)]
         var resultPaths : Array<String> = []
         
-        sut.enumerateContentsOfDirectoryAtPath(self.directoryPath, orderedByProperty: NSURLFileSizeKey, ascending: true) { (URL : NSURL, index : Int, _) -> Void in
+        sut.enumerateContentsOfDirectoryAtPath(self.directoryPath, orderedByProperty: URLResourceKey.fileSizeKey, ascending: true) { (URL : Foundation.URL, index : Int, _) -> Void in
             resultPaths.append(URL.path!)
         }
         
@@ -83,12 +83,12 @@ class NSFileManager_HanekeTests: DiskTestCase {
     }
     
     func testEnumerateContentsOfDirectoryAtPathFileSizeDescending() {
-        let sut = NSFileManager.defaultManager()
+        let sut = FileManager.default
         
-        let paths : [String] = [self.writeDataWithLength(1), self.writeDataWithLength(2)].reverse()
+        let paths : [String] = [self.writeDataWithLength(1), self.writeDataWithLength(2)].reversed()
         var resultPaths : [String] = []
         
-        sut.enumerateContentsOfDirectoryAtPath(self.directoryPath, orderedByProperty: NSURLFileSizeKey, ascending: false) { (URL : NSURL, index : Int, _) -> Void in
+        sut.enumerateContentsOfDirectoryAtPath(self.directoryPath, orderedByProperty: URLResourceKey.fileSizeKey, ascending: false) { (URL : Foundation.URL, index : Int, _) -> Void in
             resultPaths.append(URL.path!)
         }
         
@@ -97,14 +97,14 @@ class NSFileManager_HanekeTests: DiskTestCase {
     }
     
     func testEnumerateContentsOfDirectoryAtPathModificationDateAscending() {
-        let sut = NSFileManager.defaultManager()
+        let sut = FileManager.default
         
         let paths = [self.writeDataWithLength(1), self.writeDataWithLength(2)]
-        try! sut.setAttributes([NSFileModificationDate : NSDate.distantPast()], ofItemAtPath: paths[0])
+        try! sut.setAttributes([FileAttributeKey.modificationDate : Date.distantPast], ofItemAtPath: paths[0])
         
         var resultPaths : Array<String> = []
         
-        sut.enumerateContentsOfDirectoryAtPath(self.directoryPath, orderedByProperty: NSURLContentModificationDateKey, ascending: true) { (URL : NSURL, index : Int, _) -> Void in
+        sut.enumerateContentsOfDirectoryAtPath(self.directoryPath, orderedByProperty: URLResourceKey.contentModificationDateKey, ascending: true) { (URL : Foundation.URL, index : Int, _) -> Void in
             resultPaths.append(URL.path!)
         }
         
@@ -113,13 +113,13 @@ class NSFileManager_HanekeTests: DiskTestCase {
     }
     
     func testEnumerateContentsOfDirectoryAtPathModificationDateDescending() {
-        let sut = NSFileManager.defaultManager()
+        let sut = FileManager.default
         
         let paths = [self.writeDataWithLength(1), self.writeDataWithLength(2)]
-        try! sut.setAttributes([NSFileModificationDate : NSDate.distantPast()], ofItemAtPath: paths[1])
+        try! sut.setAttributes([FileAttributeKey.modificationDate : Date.distantPast], ofItemAtPath: paths[1])
         var resultPaths : Array<String> = []
         
-        sut.enumerateContentsOfDirectoryAtPath(self.directoryPath, orderedByProperty: NSURLContentModificationDateKey, ascending: false) { (URL : NSURL, index : Int, _) -> Void in
+        sut.enumerateContentsOfDirectoryAtPath(self.directoryPath, orderedByProperty: URLResourceKey.contentModificationDateKey, ascending: false) { (URL : Foundation.URL, index : Int, _) -> Void in
             resultPaths.append(URL.path!)
         }
         

--- a/HanekeTests/NSHTTPURLResponse+HanekeTests.swift
+++ b/HanekeTests/NSHTTPURLResponse+HanekeTests.swift
@@ -9,8 +9,8 @@
 import XCTest
 @testable import Haneke
 
-func responseWithStatusCode(statusCode : Int) -> NSHTTPURLResponse {
-    return NSHTTPURLResponse(URL: NSURL(string: "http://haneke.io")!, statusCode: statusCode, HTTPVersion: "HTTP/1.1", headerFields: nil)!
+func responseWithStatusCode(_ statusCode : Int) -> HTTPURLResponse {
+    return HTTPURLResponse(url: URL(string: "http://haneke.io")!, statusCode: statusCode, httpVersion: "HTTP/1.1", headerFields: nil)!
 }
 
 class NSHTTPURLResponse_HanekeTests: XCTestCase {

--- a/HanekeTests/NSURLResponse+HanekeTests.swift
+++ b/HanekeTests/NSURLResponse+HanekeTests.swift
@@ -11,60 +11,60 @@ import XCTest
 
 class NSURLResponse_HanekeTests: XCTestCase {
 
-    let httpURL = NSURL(string: "http://haneke.io")!
-    let fileURL = NSURL(string: "file:///image.png")!
+    let httpURL = URL(string: "http://haneke.io")!
+    let fileURL = URL(string: "file:///image.png")!
     
     func testValidateLengthOfData_NSHTTPURLResponse_Unknown() {
-        let response = NSHTTPURLResponse(URL: httpURL, statusCode: 200, HTTPVersion: "HTTP/1.1", headerFields: nil)!
-        let data = NSData.dataWithLength(132)
+        let response = HTTPURLResponse(url: httpURL, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: nil)!
+        let data = Data.dataWithLength(132)
         XCTAssertTrue(response.hnk_validateLengthOfData(data))
     }
     
     func testValidateLengthOfData_NSHTTPURLResponse_Expected() {
         let length = 73
-        let response = NSHTTPURLResponse(URL: httpURL, statusCode: 200, HTTPVersion: "HTTP/1.1", headerFields: ["Content-Length": String(length)])!
-        let data = NSData.dataWithLength(length)
+        let response = HTTPURLResponse(url: httpURL, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: ["Content-Length": String(length)])!
+        let data = Data.dataWithLength(length)
         XCTAssertTrue(response.hnk_validateLengthOfData(data))
     }
     
     func testValidateLengthOfData_NSHTTPURLResponse_LessThanExpected() {
         let length = 73
-        let response = NSHTTPURLResponse(URL: httpURL, statusCode: 200, HTTPVersion: "HTTP/1.1", headerFields: ["Content-Length": String(length)])!
-        let data = NSData.dataWithLength(length - 10)
+        let response = HTTPURLResponse(url: httpURL, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: ["Content-Length": String(length)])!
+        let data = Data.dataWithLength(length - 10)
         XCTAssertFalse(response.hnk_validateLengthOfData(data))
     }
     
     func testValidateLengthOfData_NSHTTPURLResponse_MoreThanExpected() {
         let length = 73
-        let response = NSHTTPURLResponse(URL: httpURL, statusCode: 200, HTTPVersion: "HTTP/1.1", headerFields: ["Content-Length": String(length)])!
-        let data = NSData.dataWithLength(length + 10)
+        let response = HTTPURLResponse(url: httpURL, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: ["Content-Length": String(length)])!
+        let data = Data.dataWithLength(length + 10)
         XCTAssertTrue(response.hnk_validateLengthOfData(data))
     }
     
     func testValidateLengthOfData_NSURLResponse_Unknown() {
-        let response = NSURLResponse(URL: fileURL, MIMEType: "image/png", expectedContentLength: -1, textEncodingName: nil)
-        let data = NSData.dataWithLength(73)
+        let response = URLResponse(url: fileURL, mimeType: "image/png", expectedContentLength: -1, textEncodingName: nil)
+        let data = Data.dataWithLength(73)
         XCTAssertTrue(response.hnk_validateLengthOfData(data))
     }
     
     func testValidateLengthOfData_NSURLResponse_Expected() {
         let length = 73
-        let response = NSURLResponse(URL: fileURL, MIMEType: "image/png", expectedContentLength: length, textEncodingName: nil)
-        let data = NSData.dataWithLength(length)
+        let response = URLResponse(url: fileURL, mimeType: "image/png", expectedContentLength: length, textEncodingName: nil)
+        let data = Data.dataWithLength(length)
         XCTAssertTrue(response.hnk_validateLengthOfData(data))
     }
     
     func testValidateLengthOfData_NSURLResponse_LessThanExpected() {
         let length = 73
-        let response = NSURLResponse(URL: fileURL, MIMEType: "image/png", expectedContentLength: length, textEncodingName: nil)
-        let data = NSData.dataWithLength(length - 10)
+        let response = URLResponse(url: fileURL, mimeType: "image/png", expectedContentLength: length, textEncodingName: nil)
+        let data = Data.dataWithLength(length - 10)
         XCTAssertFalse(response.hnk_validateLengthOfData(data))
     }
     
     func testValidateLengthOfData_NSURLResponse_MoreThanExpected() {
         let length = 73
-        let response = NSURLResponse(URL: fileURL, MIMEType: "image/png", expectedContentLength: length, textEncodingName: nil)
-        let data = NSData.dataWithLength(length + 10)
+        let response = URLResponse(url: fileURL, mimeType: "image/png", expectedContentLength: length, textEncodingName: nil)
+        let data = Data.dataWithLength(length + 10)
         XCTAssertTrue(response.hnk_validateLengthOfData(data))
     }
 }

--- a/HanekeTests/NetworkFetcherTests.swift
+++ b/HanekeTests/NetworkFetcherTests.swift
@@ -13,7 +13,7 @@ import OHHTTPStubs
 
 class NetworkFetcherTests: XCTestCase {
 
-    let URL = NSURL(string: "http://haneke.io/image.jpg")!
+    let URL = Foundation.URL(string: "http://haneke.io/image.jpg")!
     var sut : NetworkFetcher<UIImage>!
     
     override func setUp() {
@@ -35,14 +35,14 @@ class NetworkFetcherTests: XCTestCase {
     }
     
     func testFetchImage_Success() {
-        let image = UIImage.imageWithColor(UIColor.greenColor())
+        let image = UIImage.imageWithColor(UIColor.green)
         OHHTTPStubs.stubRequestsPassingTest({ _ in
             return true
         }, withStubResponse: { _ in
             let data = UIImagePNGRepresentation(image)
             return OHHTTPStubsResponse(data: data!, statusCode: 200, headers:nil)
         })
-        let expectation = self.expectationWithDescription(self.name!)
+        let expectation = self.expectation(description: self.name!)
         
         sut.fetch(failure: { _ in
             XCTFail("expected success")
@@ -53,7 +53,7 @@ class NetworkFetcherTests: XCTestCase {
             expectation.fulfill()
         }
         
-        self.waitForExpectationsWithTimeout(1, handler: nil)
+        self.waitForExpectations(timeout: 1, handler: nil)
     }
     
     func testFetchImage_Success_StatusCode200() {
@@ -84,14 +84,14 @@ class NetworkFetcherTests: XCTestCase {
         OHHTTPStubs.stubRequestsPassingTest({ _ in
             return true
         }, withStubResponse: { _ in
-            let data = NSData()
+            let data = Data()
             return OHHTTPStubsResponse(data: data, statusCode: 200, headers:nil)
         })
-        let expectation = self.expectationWithDescription(self.name!)
+        let expectation = self.expectation(description: self.name!)
         
         sut.fetch(failure: {
             XCTAssertEqual($0!.domain, HanekeGlobals.Domain)
-            XCTAssertEqual($0!.code, HanekeGlobals.NetworkFetcher.ErrorCode.InvalidData.rawValue)
+            XCTAssertEqual($0!.code, HanekeGlobals.NetworkFetcher.ErrorCode.invalidData.rawValue)
             XCTAssertNotNil($0!.localizedDescription)
             expectation.fulfill()
         }) { _ in
@@ -99,21 +99,21 @@ class NetworkFetcherTests: XCTestCase {
             expectation.fulfill()
         }
         
-        self.waitForExpectationsWithTimeout(100000, handler: nil)
+        self.waitForExpectations(timeout: 100000, handler: nil)
     }
     
     func testFetchImage_Failure_MissingData() {
         OHHTTPStubs.stubRequestsPassingTest({ _ in
             return true
         }, withStubResponse: { _ in
-            let data = NSData.dataWithLength(100)
+            let data = Data.dataWithLength(100)
             return OHHTTPStubsResponse(data: data, statusCode: 200, headers:["Content-Length":String(data.length * 2)])
         })
-        let expectation = self.expectationWithDescription(self.name!)
+        let expectation = self.expectation(description: self.name!)
         
         sut.fetch(failure: {
             XCTAssertEqual($0!.domain, HanekeGlobals.Domain)
-            XCTAssertEqual($0!.code, HanekeGlobals.NetworkFetcher.ErrorCode.MissingData.rawValue)
+            XCTAssertEqual($0!.code, HanekeGlobals.NetworkFetcher.ErrorCode.missingData.rawValue)
             XCTAssertNotNil($0!.localizedDescription)
             expectation.fulfill()
         }) { _ in
@@ -121,11 +121,11 @@ class NetworkFetcherTests: XCTestCase {
             expectation.fulfill()
         }
         
-        self.waitForExpectationsWithTimeout(1, handler: nil)
+        self.waitForExpectations(timeout: 1, handler: nil)
     }
     
     func testCancelFetch() {
-        let image = UIImage.imageWithColor(UIColor.greenColor())
+        let image = UIImage.imageWithColor(UIColor.green)
         OHHTTPStubs.stubRequestsPassingTest({ _ in
             return true
         }, withStubResponse: { _ in
@@ -148,20 +148,20 @@ class NetworkFetcherTests: XCTestCase {
     }
     
     func testSession() {
-        XCTAssertEqual(sut.session, NSURLSession.sharedSession())
+        XCTAssertEqual(sut.session, URLSession.shared)
     }
     
     // MARK: Private
 
-    private func testFetchImageSuccessWithStatusCode(statusCode : Int32) {
-        let image = UIImage.imageWithColor(UIColor.greenColor())
+    fileprivate func testFetchImageSuccessWithStatusCode(_ statusCode : Int32) {
+        let image = UIImage.imageWithColor(UIColor.green)
         OHHTTPStubs.stubRequestsPassingTest({ _ in
             return true
             }, withStubResponse: { _ in
                 let data = UIImagePNGRepresentation(image)
                 return OHHTTPStubsResponse(data: data!, statusCode: statusCode, headers:nil)
         })
-        let expectation = self.expectationWithDescription(self.name!)
+        let expectation = self.expectation(description: self.name!)
         sut.cancelFetch()
 
         sut.fetch(failure: { _ in
@@ -173,21 +173,21 @@ class NetworkFetcherTests: XCTestCase {
                 expectation.fulfill()
         }
 
-        self.waitForExpectationsWithTimeout(1, handler: nil)
+        self.waitForExpectations(timeout: 1, handler: nil)
     }
 
-    private func testFetchImageFailureWithInvalidStatusCode(statusCode : Int32) {
+    fileprivate func testFetchImageFailureWithInvalidStatusCode(_ statusCode : Int32) {
         OHHTTPStubs.stubRequestsPassingTest({ _ in
             return true
         }, withStubResponse: { _ in
-            let data = NSData.dataWithLength(100)
+            let data = Data.dataWithLength(100)
             return OHHTTPStubsResponse(data: data, statusCode: statusCode, headers:nil)
         })
-        let expectation = self.expectationWithDescription(self.name!)
+        let expectation = self.expectation(description: self.name!)
         
         sut.fetch(failure: {
             XCTAssertEqual($0!.domain, HanekeGlobals.Domain)
-            XCTAssertEqual($0!.code, HanekeGlobals.NetworkFetcher.ErrorCode.InvalidStatusCode.rawValue)
+            XCTAssertEqual($0!.code, HanekeGlobals.NetworkFetcher.ErrorCode.invalidStatusCode.rawValue)
             XCTAssertNotNil($0!.localizedDescription)
             expectation.fulfill()
         }) { _ in
@@ -195,20 +195,20 @@ class NetworkFetcherTests: XCTestCase {
             expectation.fulfill()
         }
         
-        self.waitForExpectationsWithTimeout(1, handler: nil)        
+        self.waitForExpectations(timeout: 1, handler: nil)        
     }
     
     // MARK: Cache extension
     
     func testCacheFetch_Success() {
-        let data = NSData.dataWithLength(1)
+        let data = Data.dataWithLength(1)
         OHHTTPStubs.stubRequestsPassingTest({ _ in
             return true
             }, withStubResponse: { _ in
                 return OHHTTPStubsResponse(data: data, statusCode: 200, headers:nil)
         })
-        let expectation = self.expectationWithDescription(self.name!)
-        let cache = Cache<NSData>(name: self.name!)
+        let expectation = self.expectation(description: self.name!)
+        let cache = Cache<Data>(name: self.name!)
 
         cache.fetch(URL: URL, failure: {_ in
             XCTFail("expected success")
@@ -218,20 +218,20 @@ class NetworkFetcherTests: XCTestCase {
             expectation.fulfill()
         }
         
-        self.waitForExpectationsWithTimeout(1, handler: nil)
+        self.waitForExpectations(timeout: 1, handler: nil)
         
         cache.removeAll()
     }
     
     func testCacheFetch_Failure() {
-        let data = NSData.dataWithLength(1)
+        let data = Data.dataWithLength(1)
         OHHTTPStubs.stubRequestsPassingTest({ _ in
             return true
             }, withStubResponse: { _ in
                 return OHHTTPStubsResponse(data: data, statusCode: 404, headers:nil)
         })
-        let expectation = self.expectationWithDescription(self.name!)
-        let cache = Cache<NSData>(name: self.name!)
+        let expectation = self.expectation(description: self.name!)
+        let cache = Cache<Data>(name: self.name!)
         
         cache.fetch(URL: URL, failure: {_ in
             expectation.fulfill()
@@ -240,21 +240,21 @@ class NetworkFetcherTests: XCTestCase {
             expectation.fulfill()
         }
         
-        self.waitForExpectationsWithTimeout(1, handler: nil)
+        self.waitForExpectations(timeout: 1, handler: nil)
         
         cache.removeAll()
     }
     
     func testCacheFetch_WithFormat() {
-        let data = NSData.dataWithLength(1)
+        let data = Data.dataWithLength(1)
         OHHTTPStubs.stubRequestsPassingTest({ _ in
             return true
             }, withStubResponse: { _ in
                 return OHHTTPStubsResponse(data: data, statusCode: 404, headers:nil)
         })
-        let expectation = self.expectationWithDescription(self.name!)
-        let cache = Cache<NSData>(name: self.name!)
-        let format = Format<NSData>(name: self.name!)
+        let expectation = self.expectation(description: self.name!)
+        let cache = Cache<Data>(name: self.name!)
+        let format = Format<Data>(name: self.name!)
         cache.addFormat(format)
 
         cache.fetch(URL: URL, formatName: format.name, failure: {_ in
@@ -264,7 +264,7 @@ class NetworkFetcherTests: XCTestCase {
             expectation.fulfill()
         }
         
-        self.waitForExpectationsWithTimeout(1, handler: nil)
+        self.waitForExpectations(timeout: 1, handler: nil)
         
         cache.removeAll()
     }

--- a/HanekeTests/String+HanekeTests.swift
+++ b/HanekeTests/String+HanekeTests.swift
@@ -34,12 +34,12 @@ class String_HanekeTests: XCTestCase {
     func testMD5Filename() {
         XCTAssertEqual("".MD5Filename(), "".MD5String())
         XCTAssertEqual("test".MD5Filename(), "test".MD5String())
-        XCTAssertEqual("test.png".MD5Filename(), ("test.png".MD5String() as NSString).stringByAppendingPathExtension("png"))
+        XCTAssertEqual("test.png".MD5Filename(), ("test.png".MD5String() as NSString).appendingPathExtension("png"))
     }
 
     func testMD5Filename_QueryString() {
         let sut = "test.png?width=100&height=200"
-        XCTAssertEqual(sut.MD5Filename(), (sut.MD5String() as NSString).stringByAppendingPathExtension("png"))
+        XCTAssertEqual(sut.MD5Filename(), (sut.MD5String() as NSString).appendingPathExtension("png"))
     }
 
 }

--- a/HanekeTests/UIButton+HanekeTests.swift
+++ b/HanekeTests/UIButton+HanekeTests.swift
@@ -17,7 +17,7 @@ class UIButton_HanekeTests: DiskTestCase {
     
     override func setUp() {
         super.setUp()
-        sut = UIButton(frame: CGRectMake(0, 0, 100, 20))
+        sut = UIButton(frame: CGRect(x: 0, y: 0, width: 100, height: 20))
     }
     
     override func tearDown() {
@@ -32,10 +32,10 @@ class UIButton_HanekeTests: DiskTestCase {
     // MARK: imageFormat
     
     func testImageFormat_Default() {
-        let formatSize = sut.contentRectForBounds(sut.bounds).size
+        let formatSize = sut.contentRect(forBounds: sut.bounds).size
         let format = sut.hnk_imageFormat
         let resizer = ImageResizer(size: formatSize, scaleMode: .AspectFit, allowUpscaling: false, compressionQuality: HanekeGlobals.UIKit.DefaultFormat.CompressionQuality)
-        let image = UIImage.imageWithColor(UIColor.redColor())
+        let image = UIImage.imageWithColor(UIColor.red)
         
         XCTAssertEqual(format.diskCapacity, HanekeGlobals.UIKit.DefaultFormat.DiskCapacity)
         let result = format.apply(image)
@@ -46,62 +46,62 @@ class UIButton_HanekeTests: DiskTestCase {
     // MARK: setImage
     
     func testSetImage_MemoryMiss_UIControlStateNormal() {
-        let image = UIImage.imageWithColor(UIColor.greenColor())
+        let image = UIImage.imageWithColor(UIColor.green)
         let key = self.name!
         
         sut.hnk_setImage(image, key: key)
         
-        XCTAssertNil(sut.imageForState(.Normal))
+        XCTAssertNil(sut.image(for: UIControlState()))
         XCTAssertEqual(sut.hnk_imageFetcher.key, key)
     }
     
     func testSetImage_MemoryHit_UIControlStateSelected() {
-        let image = UIImage.imageWithColor(UIColor.greenColor())
+        let image = UIImage.imageWithColor(UIColor.green)
         let key = self.name!
         let expectedImage = setImage(image, key: key, format: sut.hnk_imageFormat)
         
-        sut.hnk_setImage(image, key: key, state: .Selected)
+        sut.hnk_setImage(image, key: key, state: .selected)
         
-        XCTAssertTrue(sut.imageForState(.Selected)?.isEqualPixelByPixel(expectedImage) == true)
+        XCTAssertTrue(sut.image(for: .selected)?.isEqualPixelByPixel(expectedImage) == true)
         XCTAssertTrue(sut.hnk_imageFetcher == nil)
     }
     
     func testSetImage_UsingPlaceholder_MemoryMiss_UIControlStateDisabled() {
-        let placeholder = UIImage.imageWithColor(UIColor.yellowColor())
-        let image = UIImage.imageWithColor(UIColor.greenColor())
+        let placeholder = UIImage.imageWithColor(UIColor.yellow)
+        let image = UIImage.imageWithColor(UIColor.green)
         let key = self.name!
         
-        sut.hnk_setImage(image, key: key, state: .Disabled, placeholder: placeholder)
+        sut.hnk_setImage(image, key: key, state: .disabled, placeholder: placeholder)
         
-        XCTAssertEqual(sut.imageForState(.Disabled)!, placeholder)
+        XCTAssertEqual(sut.image(for: .disabled)!, placeholder)
         XCTAssertEqual(sut.hnk_imageFetcher.key, key)
     }
     
     func testSetImage_UsingPlaceholder_MemoryHit_UIControlStateNormal() {
-        let placeholder = UIImage.imageWithColor(UIColor.yellowColor())
-        let image = UIImage.imageWithColor(UIColor.greenColor())
+        let placeholder = UIImage.imageWithColor(UIColor.yellow)
+        let image = UIImage.imageWithColor(UIColor.green)
         let key = self.name!
         let expectedImage = setImage(image, key: key, format: sut.hnk_imageFormat)
         
         sut.hnk_setImage(image, key: key, placeholder: placeholder)
         
-        XCTAssertTrue(sut.imageForState(.Normal)?.isEqualPixelByPixel(expectedImage) == true)
+        XCTAssertTrue(sut.image(for: UIControlState())?.isEqualPixelByPixel(expectedImage) == true)
         XCTAssertTrue(sut.hnk_imageFetcher == nil)
     }
     
     func testSetImage_UsingFormat_UIControlStateHighlighted() {
-        let image = UIImage.imageWithColor(UIColor.redColor())
-        let expectedImage = UIImage.imageWithColor(UIColor.greenColor())
+        let image = UIImage.imageWithColor(UIColor.red)
+        let expectedImage = UIImage.imageWithColor(UIColor.green)
         let format = Format<UIImage>(name: self.name!, diskCapacity: 0) { _ in return expectedImage }
         let key = self.name!
-        let expectation = self.expectationWithDescription(self.name!)
+        let expectation = self.expectation(description: self.name!)
         
-        sut.hnk_setImage(image, key: key, state: .Highlighted, format: format, success:{resultImage in
+        sut.hnk_setImage(image, key: key, state: .highlighted, format: format, success:{resultImage in
             XCTAssertTrue(resultImage.isEqualPixelByPixel(expectedImage))
             expectation.fulfill()
         })
         
-        self.waitForExpectationsWithTimeout(1, handler: nil)
+        self.waitForExpectations(timeout: 1, handler: nil)
     }
     
     // MARK: setImageFromFile
@@ -109,31 +109,31 @@ class UIButton_HanekeTests: DiskTestCase {
     func testSetImageFromFile_MemoryMiss_UIControlStateSelected() {
         let fetcher = DiskFetcher<UIImage>(path: self.uniquePath())
         
-        sut.hnk_setImageFromFile(fetcher.key, state: .Selected)
+        sut.hnk_setImageFromFile(fetcher.key, state: .selected)
         
-        XCTAssertNil(sut.imageForState(.Selected))
+        XCTAssertNil(sut.image(for: .selected))
         XCTAssertEqual(sut.hnk_imageFetcher.key, fetcher.key)
     }
     
     func testSetImageFromFile_MemoryHit_UIControlStateNormal() {
-        let image = UIImage.imageWithColor(UIColor.orangeColor())
+        let image = UIImage.imageWithColor(UIColor.orange)
         let fetcher = DiskFetcher<UIImage>(path: self.uniquePath())
         let expectedImage = setImage(image, key: fetcher.key, format: sut.hnk_imageFormat)
         
         sut.hnk_setImageFromFile(fetcher.key)
         
-        XCTAssertTrue(sut.imageForState(.Normal)?.isEqualPixelByPixel(expectedImage) == true)
+        XCTAssertTrue(sut.image(for: UIControlState())?.isEqualPixelByPixel(expectedImage) == true)
         XCTAssertTrue(sut.hnk_imageFetcher == nil)
     }
     
     func testSetImageFromFileSuccessFailure_MemoryHit_UIControlStateSelected() {
-        let image = UIImage.imageWithColor(UIColor.greenColor())
+        let image = UIImage.imageWithColor(UIColor.green)
         let fetcher = DiskFetcher<UIImage>(path: self.uniquePath())
         let cache = Shared.imageCache
         let format = sut.hnk_imageFormat
         cache.set(value: image, key: fetcher.key, formatName: format.name)
         
-        sut.hnk_setImageFromFile(fetcher.key, state: .Selected, failure: {error in
+        sut.hnk_setImageFromFile(fetcher.key, state: .selected, failure: {error in
             XCTFail("")
             }){result in
                 XCTAssertTrue(result.isEqualPixelByPixel(image))
@@ -143,36 +143,36 @@ class UIButton_HanekeTests: DiskTestCase {
     // MARK: setImageFromURL
     
     func testSetImageFromURL_MemoryMiss_UIControlStateSelected() {
-        let URL = NSURL(string: "http://haneke.io")!
+        let URL = Foundation.URL(string: "http://haneke.io")!
         let fetcher = NetworkFetcher<UIImage>(URL: URL)
         
-        sut.hnk_setImageFromURL(URL, state: .Selected)
+        sut.hnk_setImageFromURL(URL, state: .selected)
         
-        XCTAssertNil(sut.imageForState(.Selected))
+        XCTAssertNil(sut.image(for: .selected))
         XCTAssertEqual(sut.hnk_imageFetcher.key, fetcher.key)
     }
     
     func testSetImageFromURL_MemoryHit_UIControlStateNormal() {
-        let image = UIImage.imageWithColor(UIColor.orangeColor())
-        let URL = NSURL(string: "http://haneke.io")!
+        let image = UIImage.imageWithColor(UIColor.orange)
+        let URL = Foundation.URL(string: "http://haneke.io")!
         let fetcher = NetworkFetcher<UIImage>(URL: URL)
         let expectedImage = setImage(image, key: fetcher.key, format: sut.hnk_imageFormat)
         
         sut.hnk_setImageFromURL(URL)
         
-        XCTAssertTrue(sut.imageForState(.Normal)?.isEqualPixelByPixel(expectedImage) == true)
+        XCTAssertTrue(sut.image(for: UIControlState())?.isEqualPixelByPixel(expectedImage) == true)
         XCTAssertTrue(sut.hnk_imageFetcher == nil)
     }
     
     func testSetImageFromURLSuccessFailure_MemoryHit_UIControlStateSelected() {
-        let image = UIImage.imageWithColor(UIColor.greenColor())
-        let URL = NSURL(string: "http://haneke.io")!
+        let image = UIImage.imageWithColor(UIColor.green)
+        let URL = Foundation.URL(string: "http://haneke.io")!
         let fetcher = NetworkFetcher<UIImage>(URL: URL)
         let cache = Shared.imageCache
         let format = sut.hnk_imageFormat
         cache.set(value: image, key: fetcher.key, formatName: format.name)
         
-        sut.hnk_setImageFromURL(URL, state: .Selected, failure: {error in
+        sut.hnk_setImageFromURL(URL, state: .selected, failure: {error in
             XCTFail("")
             }){result in
                 XCTAssertTrue(result.isEqualPixelByPixel(image))
@@ -183,26 +183,26 @@ class UIButton_HanekeTests: DiskTestCase {
         OHHTTPStubs.stubRequestsPassingTest({ _ in
             return true
             }, withStubResponse: { _ in
-                let data = NSData.dataWithLength(100)
+                let data = Data.dataWithLength(100)
                 return OHHTTPStubsResponse(data: data, statusCode: 404, headers:nil)
         })
-        let URL = NSURL(string: "http://haneke.io")!
+        let URL = Foundation.URL(string: "http://haneke.io")!
         let fetcher = NetworkFetcher<UIImage>(URL: URL)
-        let expectation = self.expectationWithDescription(self.name!)
+        let expectation = self.expectation(description: self.name!)
         
         sut.hnk_setImageFromURL(URL, failure:{error in
             XCTAssertEqual(error!.domain, HanekeGlobals.Domain)
             expectation.fulfill()
         })
         
-        XCTAssertNil(sut.imageForState(.Normal))
+        XCTAssertNil(sut.image(for: UIControlState()))
         XCTAssertEqual(sut.hnk_imageFetcher.key, fetcher.key)
-        self.waitForExpectationsWithTimeout(1, handler: nil)
+        self.waitForExpectations(timeout: 1, handler: nil)
     }
     
     func testSetImageFromURL_UsingFormat() {
-        let image = UIImage.imageWithColor(UIColor.redColor())
-        let expectedImage = UIImage.imageWithColor(UIColor.greenColor())
+        let image = UIImage.imageWithColor(UIColor.red)
+        let expectedImage = UIImage.imageWithColor(UIColor.green)
         let format = Format<UIImage>(name: self.name!, diskCapacity: 0) { _ in return expectedImage }
         OHHTTPStubs.stubRequestsPassingTest({ _ in
             return true
@@ -210,62 +210,62 @@ class UIButton_HanekeTests: DiskTestCase {
                 let data = UIImagePNGRepresentation(image)
                 return OHHTTPStubsResponse(data: data!, statusCode: 200, headers:nil)
         })
-        let URL = NSURL(string: "http://haneke.io")!
-        let expectation = self.expectationWithDescription(self.name!)
+        let URL = Foundation.URL(string: "http://haneke.io")!
+        let expectation = self.expectation(description: self.name!)
         
         sut.hnk_setImageFromURL(URL, format: format, success:{resultImage in
             XCTAssertTrue(resultImage.isEqualPixelByPixel(expectedImage))
             expectation.fulfill()
         })
         
-        self.waitForExpectationsWithTimeout(1, handler: nil)
+        self.waitForExpectations(timeout: 1, handler: nil)
     }
     
     // MARK: setImageFromFetcher
 
     func testSetImageFromFetcher_Hit_Animated_UIControlStateSelected() {
-        let image = UIImage.imageWithColor(UIColor.greenColor())
+        let image = UIImage.imageWithColor(UIColor.green)
         let key = self.name!
         let fetcher = AsyncFetcher<UIImage>(key: key, value: image)
         let expectedImage = sut.hnk_imageFormat.apply(image)
 
-        sut.hnk_setImageFromFetcher(fetcher, state: .Selected)
+        sut.hnk_setImageFromFetcher(fetcher, state: .selected)
         XCTAssertTrue(sut.hnk_imageFetcher === fetcher)
-        XCTAssertNil(sut.imageForState(.Selected))
+        XCTAssertNil(sut.image(for: .selected))
 
         self.wait(1) {
-            return self.sut.imageForState(.Selected) != nil
+            return self.sut.image(for: .selected) != nil
         }
 
-        XCTAssertTrue(sut.imageForState(.Selected)?.isEqualPixelByPixel(expectedImage) == true)
+        XCTAssertTrue(sut.image(for: .selected)?.isEqualPixelByPixel(expectedImage) == true)
         XCTAssertNil(sut.hnk_imageFetcher)
     }
     
     func testSetImageFromFetcher_MemoryMiss_UIControlStateSelected() {
-        let image = UIImage.imageWithColor(UIColor.greenColor())
+        let image = UIImage.imageWithColor(UIColor.green)
         let key = self.name!
         let fetcher = SimpleFetcher<UIImage>(key: key, value: image)
         
-        sut.hnk_setImageFromFetcher(fetcher, state: .Selected)
+        sut.hnk_setImageFromFetcher(fetcher, state: .selected)
         
-        XCTAssertNil(sut.imageForState(.Selected))
+        XCTAssertNil(sut.image(for: .selected))
         XCTAssertTrue(sut.hnk_imageFetcher === fetcher)
     }
     
     func testSetImageFromFetcher_MemoryHit_UIControlStateNormal() {
-        let image = UIImage.imageWithColor(UIColor.greenColor())
+        let image = UIImage.imageWithColor(UIColor.green)
         let key = self.name!
         let fetcher = SimpleFetcher<UIImage>(key: key, value: image)
         let expectedImage = setImage(image, key: key, format: sut.hnk_imageFormat)
         
         sut.hnk_setImageFromFetcher(fetcher)
         
-        XCTAssertTrue(sut.imageForState(.Normal)?.isEqualPixelByPixel(expectedImage) == true)
+        XCTAssertTrue(sut.image(for: UIControlState())?.isEqualPixelByPixel(expectedImage) == true)
         XCTAssertTrue(sut.hnk_imageFetcher == nil)
     }
     
     func testSetImageFromFetcherSuccessFailure_MemoryHit_UIControlStateNormal() {
-        let image = UIImage.imageWithColor(UIColor.greenColor())
+        let image = UIImage.imageWithColor(UIColor.green)
         let key = self.name!
         let fetcher = SimpleFetcher<UIImage>(key: key, value: image)
         let cache = Shared.imageCache
@@ -288,7 +288,7 @@ class UIButton_HanekeTests: DiskTestCase {
     }
     
     func testCancelSetImage_AfterSetImage() {
-        let URL = NSURL(string: "http://imgs.xkcd.com/comics/election.png")!
+        let URL = Foundation.URL(string: "http://imgs.xkcd.com/comics/election.png")!
         sut.hnk_setImageFromURL(URL, success: { _ in
             XCTFail("unexpected success")
             }, failure: { _ in
@@ -302,8 +302,8 @@ class UIButton_HanekeTests: DiskTestCase {
     }
 
     func testCancelSetImage_AfterSetImage_UIControlStateHighlighted() {
-        let URL = NSURL(string: "http://imgs.xkcd.com/comics/election.png")!
-        sut.hnk_setImageFromURL(URL, state: .Highlighted, success: { _ in
+        let URL = Foundation.URL(string: "http://imgs.xkcd.com/comics/election.png")!
+        sut.hnk_setImageFromURL(URL, state: .highlighted, success: { _ in
             XCTFail("unexpected success")
             }, failure: { _ in
                 XCTFail("unexpected failure")
@@ -318,10 +318,10 @@ class UIButton_HanekeTests: DiskTestCase {
     // MARK: backgroundImageFormat
 
     func testBackgroundImageFormat_Default() {
-        let formatSize = sut.contentRectForBounds(sut.bounds).size
+        let formatSize = sut.contentRect(forBounds: sut.bounds).size
         let format = sut.hnk_backgroundImageFormat
         let resizer = ImageResizer(size: formatSize, scaleMode: .Fill, allowUpscaling: true, compressionQuality: HanekeGlobals.UIKit.DefaultFormat.CompressionQuality)
-        let image = UIImage.imageWithColor(UIColor.redColor())
+        let image = UIImage.imageWithColor(UIColor.red)
         
         XCTAssertEqual(format.diskCapacity, HanekeGlobals.UIKit.DefaultFormat.DiskCapacity)
         let result = format.apply(image)
@@ -332,64 +332,64 @@ class UIButton_HanekeTests: DiskTestCase {
     // MARK: setBackgroundImage
     
     func testSetBackgroundImage_MemoryMiss_UIControlStateNormal() {
-        let image = UIImage.imageWithColor(UIColor.greenColor())
+        let image = UIImage.imageWithColor(UIColor.green)
         let key = self.name!
         
         sut.hnk_setBackgroundImage(image, key: key)
         
-        XCTAssertNil(sut.backgroundImageForState(.Normal))
+        XCTAssertNil(sut.backgroundImage(for: UIControlState()))
         XCTAssertEqual(sut.hnk_backgroundImageFetcher.key, key)
     }
 
     func testSetBackgroundImage_MemoryHit_UIControlStateSelected() {
-        let image = UIImage.imageWithColor(UIColor.greenColor())
+        let image = UIImage.imageWithColor(UIColor.green)
         let key = self.name!
         let expectedImage = setImage(image, key: key, format: sut.hnk_backgroundImageFormat)
         
-        sut.hnk_setBackgroundImage(image, key: key, state: .Selected)
+        sut.hnk_setBackgroundImage(image, key: key, state: .selected)
         
-        let result = sut.backgroundImageForState(.Selected)
+        let result = sut.backgroundImage(for: .selected)
         XCTAssertTrue(result?.isEqualPixelByPixel(expectedImage) == true)
         XCTAssertTrue(sut.hnk_backgroundImageFetcher == nil)
     }
 
     func testSetBackgroundImage_UsingPlaceholder_MemoryMiss_UIControlStateDisabled() {
-        let placeholder = UIImage.imageWithColor(UIColor.yellowColor())
-        let image = UIImage.imageWithColor(UIColor.greenColor())
+        let placeholder = UIImage.imageWithColor(UIColor.yellow)
+        let image = UIImage.imageWithColor(UIColor.green)
         let key = self.name!
         
-        sut.hnk_setBackgroundImage(image, key: key, state: .Disabled, placeholder: placeholder)
+        sut.hnk_setBackgroundImage(image, key: key, state: .disabled, placeholder: placeholder)
         
-        XCTAssertEqual(sut.backgroundImageForState(.Disabled)!, placeholder)
+        XCTAssertEqual(sut.backgroundImage(for: .disabled)!, placeholder)
         XCTAssertEqual(sut.hnk_backgroundImageFetcher.key, key)
     }
 
     func testSetBackgroundImage_UsingPlaceholder_MemoryHit_UIControlStateNormal() {
-        let placeholder = UIImage.imageWithColor(UIColor.yellowColor())
-        let image = UIImage.imageWithColor(UIColor.greenColor())
+        let placeholder = UIImage.imageWithColor(UIColor.yellow)
+        let image = UIImage.imageWithColor(UIColor.green)
         let key = self.name!
         let expectedImage = setImage(image, key: key, format: sut.hnk_backgroundImageFormat)
         
         sut.hnk_setBackgroundImage(image, key: key, placeholder: placeholder)
         
-        let result = sut.backgroundImageForState(.Normal)
+        let result = sut.backgroundImage(for: UIControlState())
         XCTAssertTrue(result?.isEqualPixelByPixel(expectedImage) == true)
         XCTAssertTrue(sut.hnk_backgroundImageFetcher == nil)
     }
    
     func testSetBackgroundImage_UsingFormat_UIControlStateHighlighted() {
-        let image = UIImage.imageWithColor(UIColor.redColor())
-        let expectedImage = UIImage.imageWithColor(UIColor.greenColor())
+        let image = UIImage.imageWithColor(UIColor.red)
+        let expectedImage = UIImage.imageWithColor(UIColor.green)
         let key = self.name!
         let format = Format<UIImage>(name: key, diskCapacity: 0) { _ in return expectedImage }
-        let expectation = self.expectationWithDescription(key)
+        let expectation = self.expectation(description: key)
         
-        sut.hnk_setBackgroundImage(image, key: key, state: .Highlighted, format: format, success:{resultImage in
+        sut.hnk_setBackgroundImage(image, key: key, state: .highlighted, format: format, success:{resultImage in
             XCTAssertTrue(resultImage.isEqualPixelByPixel(expectedImage))
             expectation.fulfill()
         })
         
-        self.waitForExpectationsWithTimeout(1, handler: nil)
+        self.waitForExpectations(timeout: 1, handler: nil)
     }
     
     // MARK: setBackgroundImageFromFile
@@ -397,32 +397,32 @@ class UIButton_HanekeTests: DiskTestCase {
     func testSetBackgroundImageFromFile_MemoryMiss_UIControlStateSelected() {
         let fetcher = DiskFetcher<UIImage>(path: self.uniquePath())
         
-        sut.hnk_setBackgroundImageFromFile(fetcher.key, state: .Selected)
+        sut.hnk_setBackgroundImageFromFile(fetcher.key, state: .selected)
         
-        XCTAssertNil(sut.backgroundImageForState(.Selected))
+        XCTAssertNil(sut.backgroundImage(for: .selected))
         XCTAssertEqual(sut.hnk_backgroundImageFetcher.key, fetcher.key)
     }
     
     func testSetBackgroundImageFromFile_MemoryHit_UIControlStateNormal() {
-        let image = UIImage.imageWithColor(UIColor.orangeColor())
+        let image = UIImage.imageWithColor(UIColor.orange)
         let fetcher = DiskFetcher<UIImage>(path: self.uniquePath())
         let expectedImage = setImage(image, key: fetcher.key, format: sut.hnk_backgroundImageFormat)
         
         sut.hnk_setBackgroundImageFromFile(fetcher.key)
         
-        let result = sut.backgroundImageForState(.Normal)
+        let result = sut.backgroundImage(for: UIControlState())
         XCTAssertTrue(result?.isEqualPixelByPixel(expectedImage) == true)
         XCTAssertTrue(sut.hnk_backgroundImageFetcher == nil)
     }
     
     func testSetBackgroundImageFromFileSuccessFailure_MemoryHit_UIControlStateSelected() {
-        let image = UIImage.imageWithColor(UIColor.greenColor())
+        let image = UIImage.imageWithColor(UIColor.green)
         let fetcher = DiskFetcher<UIImage>(path: self.uniquePath())
         let cache = Shared.imageCache
         let format = sut.hnk_backgroundImageFormat
         cache.set(value: image, key: fetcher.key, formatName: format.name)
         
-        sut.hnk_setBackgroundImageFromFile(fetcher.key, state: .Selected, failure: {error in
+        sut.hnk_setBackgroundImageFromFile(fetcher.key, state: .selected, failure: {error in
             XCTFail("")
             }){result in
                 XCTAssertTrue(result.isEqualPixelByPixel(image))
@@ -432,37 +432,37 @@ class UIButton_HanekeTests: DiskTestCase {
     // MARK: setBackgroundImageFromURL
 
     func testSetBackgroundImageFromURL_MemoryMiss_UIControlStateSelected() {
-        let URL = NSURL(string: "http://haneke.io")!
+        let URL = Foundation.URL(string: "http://haneke.io")!
         let fetcher = NetworkFetcher<UIImage>(URL: URL)
         
-        sut.hnk_setBackgroundImageFromURL(URL, state: .Selected)
+        sut.hnk_setBackgroundImageFromURL(URL, state: .selected)
         
-        XCTAssertNil(sut.backgroundImageForState(.Selected))
+        XCTAssertNil(sut.backgroundImage(for: .selected))
         XCTAssertEqual(sut.hnk_backgroundImageFetcher.key, fetcher.key)
     }
     
     func testSetBackgroundImageFromURL_MemoryHit_UIControlStateNormal() {
-        let image = UIImage.imageWithColor(UIColor.orangeColor())
-        let URL = NSURL(string: "http://haneke.io")!
+        let image = UIImage.imageWithColor(UIColor.orange)
+        let URL = Foundation.URL(string: "http://haneke.io")!
         let fetcher = NetworkFetcher<UIImage>(URL: URL)
         let expectedImage = setImage(image, key: fetcher.key, format: sut.hnk_backgroundImageFormat)
         
         sut.hnk_setBackgroundImageFromURL(URL)
         
-        let result = sut.backgroundImageForState(.Normal)
+        let result = sut.backgroundImage(for: UIControlState())
         XCTAssertTrue(result?.isEqualPixelByPixel(expectedImage) == true)
         XCTAssertTrue(sut.hnk_backgroundImageFetcher == nil)
     }
     
     func testSetBackgroundImageFromURLSuccessFailure_MemoryHit_UIControlStateSelected() {
-        let image = UIImage.imageWithColor(UIColor.greenColor())
-        let URL = NSURL(string: "http://haneke.io")!
+        let image = UIImage.imageWithColor(UIColor.green)
+        let URL = Foundation.URL(string: "http://haneke.io")!
         let fetcher = NetworkFetcher<UIImage>(URL: URL)
         let cache = Shared.imageCache
         let format = sut.hnk_backgroundImageFormat
         cache.set(value: image, key: fetcher.key, formatName: format.name)
         
-        sut.hnk_setBackgroundImageFromURL(URL, state: .Selected, failure: {error in
+        sut.hnk_setBackgroundImageFromURL(URL, state: .selected, failure: {error in
             XCTFail("")
             }){result in
                 XCTAssertTrue(result.isEqualPixelByPixel(image))
@@ -473,26 +473,26 @@ class UIButton_HanekeTests: DiskTestCase {
         OHHTTPStubs.stubRequestsPassingTest({ _ in
             return true
             }, withStubResponse: { _ in
-                let data = NSData.dataWithLength(100)
+                let data = Data.dataWithLength(100)
                 return OHHTTPStubsResponse(data: data, statusCode: 404, headers:nil)
         })
-        let URL = NSURL(string: "http://haneke.io")!
+        let URL = Foundation.URL(string: "http://haneke.io")!
         let fetcher = NetworkFetcher<UIImage>(URL: URL)
-        let expectation = self.expectationWithDescription(self.name!)
+        let expectation = self.expectation(description: self.name!)
         
         sut.hnk_setBackgroundImageFromURL(URL, failure:{error in
             XCTAssertEqual(error!.domain, HanekeGlobals.Domain)
             expectation.fulfill()
         })
         
-        XCTAssertNil(sut.backgroundImageForState(.Normal))
+        XCTAssertNil(sut.backgroundImage(for: UIControlState()))
         XCTAssertEqual(sut.hnk_backgroundImageFetcher.key, fetcher.key)
-        self.waitForExpectationsWithTimeout(1, handler: nil)
+        self.waitForExpectations(timeout: 1, handler: nil)
     }
     
     func testSetBackgroundImageFromURL_UsingFormat() {
-        let image = UIImage.imageWithColor(UIColor.redColor())
-        let expectedImage = UIImage.imageWithColor(UIColor.greenColor())
+        let image = UIImage.imageWithColor(UIColor.red)
+        let expectedImage = UIImage.imageWithColor(UIColor.green)
         let format = Format<UIImage>(name: self.name!, diskCapacity: 0) { _ in return expectedImage }
         OHHTTPStubs.stubRequestsPassingTest({ _ in
             return true
@@ -500,63 +500,63 @@ class UIButton_HanekeTests: DiskTestCase {
                 let data = UIImagePNGRepresentation(image)
                 return OHHTTPStubsResponse(data: data!, statusCode: 200, headers:nil)
         })
-        let URL = NSURL(string: "http://haneke.io")!
-        let expectation = self.expectationWithDescription(self.name!)
+        let URL = Foundation.URL(string: "http://haneke.io")!
+        let expectation = self.expectation(description: self.name!)
         
         sut.hnk_setBackgroundImageFromURL(URL, format: format, success:{resultImage in
             XCTAssertTrue(resultImage.isEqualPixelByPixel(expectedImage))
             expectation.fulfill()
         })
         
-        self.waitForExpectationsWithTimeout(1, handler: nil)
+        self.waitForExpectations(timeout: 1, handler: nil)
     }
     
     // MARK: setBackgroundImageFromFetcher
 
     func testSetBackgroundImageFromFetcher_Hit_Animated_UIControlStateSelected() {
-        let image = UIImage.imageWithColor(UIColor.greenColor())
+        let image = UIImage.imageWithColor(UIColor.green)
         let key = self.name!
         let fetcher = AsyncFetcher<UIImage>(key: key, value: image)
         let expectedImage = sut.hnk_backgroundImageFormat.apply(image)
 
-        sut.hnk_setBackgroundImageFromFetcher(fetcher, state: .Selected)
+        sut.hnk_setBackgroundImageFromFetcher(fetcher, state: .selected)
         XCTAssertTrue(sut.hnk_backgroundImageFetcher === fetcher)
-        XCTAssertNil(sut.backgroundImageForState(.Selected))
+        XCTAssertNil(sut.backgroundImage(for: .selected))
 
         self.wait(1) {
-            return self.sut.backgroundImageForState(.Selected) != nil
+            return self.sut.backgroundImage(for: .selected) != nil
         }
 
-        XCTAssertTrue(sut.backgroundImageForState(.Selected)?.isEqualPixelByPixel(expectedImage) == true)
+        XCTAssertTrue(sut.backgroundImage(for: .selected)?.isEqualPixelByPixel(expectedImage) == true)
         XCTAssertNil(sut.hnk_backgroundImageFetcher)
     }
     
     func testSetBackgroundImageFromFetcher_MemoryMiss_UIControlStateSelected() {
-        let image = UIImage.imageWithColor(UIColor.greenColor())
+        let image = UIImage.imageWithColor(UIColor.green)
         let key = self.name!
         let fetcher = SimpleFetcher<UIImage>(key: key, value: image)
         
-        sut.hnk_setBackgroundImageFromFetcher(fetcher, state: .Selected)
+        sut.hnk_setBackgroundImageFromFetcher(fetcher, state: .selected)
         
-        XCTAssertNil(sut.backgroundImageForState(.Selected))
+        XCTAssertNil(sut.backgroundImage(for: .selected))
         XCTAssertTrue(sut.hnk_backgroundImageFetcher === fetcher)
     }
     
     func testSetBackgroundImageFromFetcher_MemoryHit_UIControlStateNormal() {
-        let image = UIImage.imageWithColor(UIColor.greenColor())
+        let image = UIImage.imageWithColor(UIColor.green)
         let key = self.name!
         let fetcher = SimpleFetcher<UIImage>(key: key, value: image)
         let expectedImage = setImage(image, key: key, format: sut.hnk_backgroundImageFormat)
         
         sut.hnk_setBackgroundImageFromFetcher(fetcher)
 
-        let result = sut.backgroundImageForState(.Normal)
+        let result = sut.backgroundImage(for: UIControlState())
         XCTAssertTrue(result?.isEqualPixelByPixel(expectedImage) == true)
         XCTAssertTrue(sut.hnk_backgroundImageFetcher == nil)
     }
     
     func testSetBackgroundImageFromFetcherSuccessFailure_MemoryHit_UIControlStateNormal() {
-        let image = UIImage.imageWithColor(UIColor.greenColor())
+        let image = UIImage.imageWithColor(UIColor.green)
         let key = self.name!
         let fetcher = SimpleFetcher<UIImage>(key: key, value: image)
         let cache = Shared.imageCache
@@ -579,7 +579,7 @@ class UIButton_HanekeTests: DiskTestCase {
     }
     
     func testCancelSetBackgroundImage_AfterSetImage() {
-        let URL = NSURL(string: "http://imgs.xkcd.com/comics/election.png")!
+        let URL = Foundation.URL(string: "http://imgs.xkcd.com/comics/election.png")!
         sut.hnk_setBackgroundImageFromURL(URL, success: { _ in
             XCTFail("unexpected success")
             }, failure: { _ in
@@ -593,8 +593,8 @@ class UIButton_HanekeTests: DiskTestCase {
     }
     
     func testCancelSetBackgroundImage_AfterSetImage_UIControlStateHighlighted() {
-        let URL = NSURL(string: "http://imgs.xkcd.com/comics/election.png")!
-        sut.hnk_setBackgroundImageFromURL(URL, state: .Highlighted, success: { _ in
+        let URL = Foundation.URL(string: "http://imgs.xkcd.com/comics/election.png")!
+        sut.hnk_setBackgroundImageFromURL(URL, state: .highlighted, success: { _ in
             XCTFail("unexpected success")
             }, failure: { _ in
                 XCTFail("unexpected failure")
@@ -608,15 +608,15 @@ class UIButton_HanekeTests: DiskTestCase {
     
     // MARK: Helpers
     
-    func setImage(image : UIImage, key: String, format : Format<UIImage>) -> UIImage {
+    func setImage(_ image : UIImage, key: String, format : Format<UIImage>) -> UIImage {
         let expectedImage = format.apply(image)
         let cache = Shared.imageCache
         cache.addFormat(format)
-        let expectation = self.expectationWithDescription("set")
+        let expectation = self.expectation(description: "set")
         cache.set(value: image, key: key, formatName: format.name) { _ in
             expectation.fulfill()
         }
-        self.waitForExpectationsWithTimeout(1, handler: nil)
+        self.waitForExpectations(timeout: 1, handler: nil)
         return expectedImage
     }
     

--- a/HanekeTests/UIImage+HanekeTests.swift
+++ b/HanekeTests/UIImage+HanekeTests.swift
@@ -13,30 +13,30 @@ import MobileCoreServices
 @testable import Haneke
 
 enum ExifOrientation : UInt32 {
-    case Up = 1
-    case Down = 3
-    case Left = 8
-    case Right = 6
-    case UpMirrored = 2
-    case DownMirrored = 4
-    case LeftMirrored = 5
-    case RightMirrored = 7
+    case up = 1
+    case down = 3
+    case left = 8
+    case right = 6
+    case upMirrored = 2
+    case downMirrored = 4
+    case leftMirrored = 5
+    case rightMirrored = 7
 }
 
 class UIImage_HanekeTests: XCTestCase {
 
     func testHasAlphaTrue() {
-        let image = UIImage.imageWithColor(UIColor.redColor(), CGSize(width: 1, height: 1), false)
+        let image = UIImage.imageWithColor(UIColor.red, false, CGSize(width: 1, height: 1))
         XCTAssertTrue(image.hnk_hasAlpha())
     }
     
     func testHasAlphaFalse() {
-        let image = UIImage.imageWithColor(UIColor.redColor(), CGSize(width: 1, height: 1), true)
+        let image = UIImage.imageWithColor(UIColor.red, true, CGSize(width: 1, height: 1))
         XCTAssertFalse(image.hnk_hasAlpha())
     }
     
     func testDataPNG() {
-        let image = UIImage.imageWithColor(UIColor.redColor(), CGSize(width: 1, height: 1), false)
+        let image = UIImage.imageWithColor(UIColor.red, false, CGSize(width: 1, height: 1))
         let expectedData = UIImagePNGRepresentation(image)
         
         let data = image.hnk_data()
@@ -45,7 +45,7 @@ class UIImage_HanekeTests: XCTestCase {
     }
     
     func testDataJPEG() {
-        let image = UIImage.imageWithColor(UIColor.redColor(), CGSize(width: 1, height: 1), true)
+        let image = UIImage.imageWithColor(UIColor.red, true, CGSize(width: 1, height: 1))
         let expectedData = UIImageJPEGRepresentation(image, 1)
         
         let data = image.hnk_data()
@@ -60,7 +60,7 @@ class UIImage_HanekeTests: XCTestCase {
     }
     
     func testDecompressedImage_UIGraphicsContext_Opaque() {
-        let image = UIImage.imageWithColor(UIColor.redColor(), CGSizeMake(10, 10))
+        let image = UIImage.imageWithColor(UIColor.red, CGSize(width: 10, height: 10))
 
         let decompressedImage = image.hnk_decompressedImage()
         
@@ -69,7 +69,7 @@ class UIImage_HanekeTests: XCTestCase {
     }
     
     func testDecompressedImage_UIGraphicsContext_NotOpaque() {
-        let image = UIImage.imageWithColor(UIColor.redColor(), CGSizeMake(10, 10), false)
+        let image = UIImage.imageWithColor(UIColor.red, false, CGSize(width: 10, height: 10))
         
         let decompressedImage = image.hnk_decompressedImage()
         
@@ -79,62 +79,62 @@ class UIImage_HanekeTests: XCTestCase {
     
     func testDecompressedImage_RGBA() {
         let color = UIColor(red:255, green:0, blue:0, alpha:0.5)
-        self._testDecompressedImageUsingColor(color, alphaInfo: .PremultipliedLast)
+        self._testDecompressedImageUsingColor(color, alphaInfo: .premultipliedLast)
     }
     
     func testDecompressedImage_ARGB() {
         let color = UIColor(red:255, green:0, blue:0, alpha:0.5)
-        self._testDecompressedImageUsingColor(color, alphaInfo: .PremultipliedFirst)
+        self._testDecompressedImageUsingColor(color, alphaInfo: .premultipliedFirst)
     }
     
     func testDecompressedImage_RGBX() {
-        self._testDecompressedImageUsingColor(alphaInfo: .NoneSkipLast)
+        self._testDecompressedImageUsingColor(alphaInfo: .noneSkipLast)
     }
     
     func testDecompressedImage_XRGB() {
-        self._testDecompressedImageUsingColor(alphaInfo: .NoneSkipFirst)
+        self._testDecompressedImageUsingColor(alphaInfo: .noneSkipFirst)
     }
     
     func testDecompressedImage_Gray_AlphaNone() {
-        let color = UIColor.grayColor()
+        let color = UIColor.gray
         let colorSpaceRef = CGColorSpaceCreateDeviceGray()
-        self._testDecompressedImageUsingColor(color, colorSpace: colorSpaceRef!, alphaInfo: .None)
+        self._testDecompressedImageUsingColor(color, colorSpace: colorSpaceRef, alphaInfo: .none)
     }
     
     func testDecompressedImage_OrientationUp() {
-        self._testDecompressedImageWithOrientation(.Up)
+        self._testDecompressedImageWithOrientation(.up)
     }
     
     func testDecompressedImage_OrientationDown() {
-        self._testDecompressedImageWithOrientation(.Down)
+        self._testDecompressedImageWithOrientation(.down)
     }
     
     func testDecompressedImage_OrientationLeft() {
-        self._testDecompressedImageWithOrientation(.Left)
+        self._testDecompressedImageWithOrientation(.left)
     }
     
     func testDecompressedImage_OrientationRight() {
-        self._testDecompressedImageWithOrientation(.Right)
+        self._testDecompressedImageWithOrientation(.right)
     }
     
     func testDecompressedImage_OrientationUpMirrored() {
-        self._testDecompressedImageWithOrientation(.UpMirrored)
+        self._testDecompressedImageWithOrientation(.upMirrored)
     }
     
     func testDecompressedImage_OrientationDownMirrored() {
-        self._testDecompressedImageWithOrientation(.DownMirrored)
+        self._testDecompressedImageWithOrientation(.downMirrored)
     }
     
     func testDecompressedImage_OrientationLeftMirrored() {
-        self._testDecompressedImageWithOrientation(.LeftMirrored)
+        self._testDecompressedImageWithOrientation(.leftMirrored)
     }
     
     func testDecompressedImage_OrientationRightMirrored() {
-        self._testDecompressedImageWithOrientation(.RightMirrored)
+        self._testDecompressedImageWithOrientation(.rightMirrored)
     }
     
     func testDataCompressionQuality() {
-        let image = UIImage.imageWithColor(UIColor.redColor(), CGSizeMake(10, 10))
+        let image = UIImage.imageWithColor(UIColor.red, CGSize(width: 10, height: 10))
         let data = image.hnk_data()
         let notExpectedData = image.hnk_data(compressionQuality: 0.5)
         
@@ -142,7 +142,7 @@ class UIImage_HanekeTests: XCTestCase {
     }
     
     func testDataCompressionQuality_LessThan0() {
-        let image = UIImage.imageWithColor(UIColor.redColor(), CGSizeMake(10, 10))
+        let image = UIImage.imageWithColor(UIColor.red, CGSize(width: 10, height: 10))
         let data = image.hnk_data(compressionQuality: -1.0)
         let expectedData = image.hnk_data(compressionQuality: 0.0)
         
@@ -150,7 +150,7 @@ class UIImage_HanekeTests: XCTestCase {
     }
     
     func testDataCompressionQuality_MoreThan1() {
-        let image = UIImage.imageWithColor(UIColor.redColor(), CGSizeMake(10, 10))
+        let image = UIImage.imageWithColor(UIColor.red, CGSize(width: 10, height: 10))
         let data = image.hnk_data(compressionQuality: 10.0)
         let expectedData = image.hnk_data(compressionQuality: 1.0)
         
@@ -159,34 +159,34 @@ class UIImage_HanekeTests: XCTestCase {
     
     // MARK: Helpers
     
-    func _testDecompressedImageUsingColor(color : UIColor = UIColor.greenColor(), colorSpace: CGColorSpaceRef = CGColorSpaceCreateDeviceRGB()!, alphaInfo :CGImageAlphaInfo, bitsPerComponent : size_t = 8) {
-        let size = CGSizeMake(10, 20) // Using rectangle to check if image is rotated
-        let bitmapInfo = CGBitmapInfo.ByteOrderDefault.rawValue | alphaInfo.rawValue
-        let context = CGBitmapContextCreate(nil, Int(size.width), Int(size.height), bitsPerComponent, 0, colorSpace, bitmapInfo)
+    func _testDecompressedImageUsingColor(_ color : UIColor = UIColor.green, colorSpace: CGColorSpace = CGColorSpaceCreateDeviceRGB(), alphaInfo :CGImageAlphaInfo, bitsPerComponent : size_t = 8) {
+        let size = CGSize(width: 10, height: 20) // Using rectangle to check if image is rotated
+        let bitmapInfo = CGBitmapInfo().rawValue | alphaInfo.rawValue
+        let context = CGContext(data: nil, width: Int(size.width), height: Int(size.height), bitsPerComponent: bitsPerComponent, bytesPerRow: 0, space: colorSpace, bitmapInfo: bitmapInfo)
     
-        CGContextSetFillColorWithColor(context, color.CGColor)
-        CGContextFillRect(context, CGRectMake(0, 0, size.width, size.height))
-        let imageRef = CGBitmapContextCreateImage(context)!
+        context?.setFillColor(color.cgColor)
+        context?.fill(CGRect(x: 0, y: 0, width: size.width, height: size.height))
+        let imageRef = context?.makeImage()!
     
-        let image = UIImage(CGImage: imageRef, scale:UIScreen.mainScreen().scale, orientation:.Up)
+        let image = UIImage(cgImage: imageRef!, scale:UIScreen.main.scale, orientation:.up)
         let decompressedImage = image.hnk_decompressedImage()
     
         XCTAssertNotEqual(image, decompressedImage)
         XCTAssertTrue(decompressedImage.isEqualPixelByPixel(image), self.name!)
     }
     
-    func _testDecompressedImageWithOrientation(orientation : ExifOrientation) {
+    func _testDecompressedImageWithOrientation(_ orientation : ExifOrientation) {
         // Create a gradient image to truly test orientation
         let gradientImage = UIImage.imageGradientFromColor()
         
         // Use TIFF because PNG doesn't store EXIF orientation
         let exifProperties = NSDictionary(dictionary: [kCGImagePropertyOrientation: Int(orientation.rawValue)])
         let data = NSMutableData()
-        let imageDestinationRef = CGImageDestinationCreateWithData(data as CFMutableDataRef, kUTTypeTIFF, 1, nil)!
-        CGImageDestinationAddImage(imageDestinationRef, gradientImage.CGImage!, exifProperties as CFDictionaryRef)
+        let imageDestinationRef = CGImageDestinationCreateWithData(data as CFMutableData, kUTTypeTIFF, 1, nil)!
+        CGImageDestinationAddImage(imageDestinationRef, gradientImage.cgImage!, exifProperties as CFDictionary)
         CGImageDestinationFinalize(imageDestinationRef)
         
-        let image = UIImage(data:data, scale:UIScreen.mainScreen().scale)!
+        let image = UIImage(data:data as Data, scale:UIScreen.main.scale)!
         
         let decompressedImage = image.hnk_decompressedImage()
         

--- a/HanekeTests/UIImage+Test.swift
+++ b/HanekeTests/UIImage+Test.swift
@@ -10,35 +10,35 @@ import UIKit
 
 extension UIImage {
     
-    func isEqualPixelByPixel(theOtherImage: UIImage) -> Bool {
+    func isEqualPixelByPixel(_ theOtherImage: UIImage) -> Bool {
         let imageData = self.normalizedData()
         let theOtherImageData = theOtherImage.normalizedData()
-        return imageData.isEqualToData(theOtherImageData)
+        return (imageData == theOtherImageData)
     }
     
-    func normalizedData() -> NSData {
+    func normalizedData() -> Data {
         let pixelSize = CGSize(width : self.size.width * self.scale, height : self.size.height * self.scale)
         NSLog(NSStringFromCGSize(pixelSize))
         UIGraphicsBeginImageContext(pixelSize)
-        self.drawInRect(CGRect(x: 0, y: 0, width: pixelSize.width, height: pixelSize.height))
+        self.draw(in: CGRect(x: 0, y: 0, width: pixelSize.width, height: pixelSize.height))
         let drawnImage = UIGraphicsGetImageFromCurrentImageContext()
         UIGraphicsEndImageContext()
-        let provider = CGImageGetDataProvider(drawnImage.CGImage)
-        let data = CGDataProviderCopyData(provider)
-        return data!
+        let provider = drawnImage?.cgImage?.dataProvider
+        let data = provider?.data
+        return data! as Data
     }
     
-    class func imageWithColor(color: UIColor, _ size: CGSize = CGSize(width: 1, height: 1), _ opaque: Bool = true) -> UIImage {
+    class func imageWithColor(_ color: UIColor, _ size: CGSize = CGSize(width: 1, height: 1), _ opaque: Bool = true) -> UIImage {
         UIGraphicsBeginImageContextWithOptions(size, opaque, 0)
         let context = UIGraphicsGetCurrentContext()
-        CGContextSetFillColorWithColor(context, color.CGColor)
-        CGContextFillRect(context, CGRectMake(0, 0, size.width, size.height))
+        context?.setFillColor(color.cgColor)
+        context?.fill(CGRect(x: 0, y: 0, width: size.width, height: size.height))
         let image = UIGraphicsGetImageFromCurrentImageContext()
         UIGraphicsEndImageContext()
-        return image
+        return image!
     }
     
-    class func imageGradientFromColor(fromColor : UIColor = UIColor.redColor(), toColor : UIColor = UIColor.greenColor(), size : CGSize = CGSizeMake(10, 20)) -> UIImage {
+    class func imageGradientFromColor(_ fromColor : UIColor = UIColor.red, toColor : UIColor = UIColor.green, size : CGSize = CGSize(width: 10, height: 20)) -> UIImage {
         UIGraphicsBeginImageContextWithOptions(size, false /* opaque */, 0 /* scale */)
         let context = UIGraphicsGetCurrentContext()
         let colorspace = CGColorSpaceCreateDeviceRGB()
@@ -49,11 +49,11 @@ extension UIImage {
         var r2 : CGFloat = 0, g2 : CGFloat = 0 , b2 : CGFloat = 0, a2 : CGFloat = 0
         toColor.getRed(&r2, green: &g2, blue: &b2, alpha: &a2)
         let gradientComponents = [r1, g1, b1, a1, r2, g2, b2, a2]
-        let gradient = CGGradientCreateWithColorComponents (colorspace, gradientComponents, gradientLocations, gradientNumberOfLocations)
-        CGContextDrawLinearGradient(context, gradient, CGPointMake(0, 0), CGPointMake(0, size.height), CGGradientDrawingOptions())
+        let gradient = CGGradient (colorSpace: colorspace, colorComponents: gradientComponents, locations: gradientLocations, count: gradientNumberOfLocations)
+        context?.drawLinearGradient(gradient!, start: CGPoint(x: 0, y: 0), end: CGPoint(x: 0, y: size.height), options: CGGradientDrawingOptions())
         let image = UIGraphicsGetImageFromCurrentImageContext()
         UIGraphicsEndImageContext()
-        return image
+        return image!
     }
     
 }

--- a/HanekeTests/UIImageView+HanekeTests.swift
+++ b/HanekeTests/UIImageView+HanekeTests.swift
@@ -17,7 +17,7 @@ class UIImageView_HanekeTests: DiskTestCase {
     
     override func setUp() {
         super.setUp()
-        sut = UIImageView(frame: CGRectMake(0, 0, 10, 10))
+        sut = UIImageView(frame: CGRect(x: 0, y: 0, width: 10, height: 10))
     }
     
     override func tearDown() {
@@ -29,74 +29,74 @@ class UIImageView_HanekeTests: DiskTestCase {
     }
     
     func testScaleMode_ScaleToFill() {
-        sut.contentMode = .ScaleToFill
+        sut.contentMode = .scaleToFill
         XCTAssertEqual(sut.hnk_scaleMode, ImageResizer.ScaleMode.Fill)
     }
     
     func testScaleMode_ScaleAspectFit() {
-        sut.contentMode = .ScaleAspectFit
+        sut.contentMode = .scaleAspectFit
         XCTAssertEqual(sut.hnk_scaleMode, ImageResizer.ScaleMode.AspectFit)
     }
     
     func testScaleMode_ScaleAspectFill() {
-        sut.contentMode = .ScaleAspectFill
+        sut.contentMode = .scaleAspectFill
         XCTAssertEqual(sut.hnk_scaleMode, ImageResizer.ScaleMode.AspectFill)
     }
     
     func testScaleMode_Redraw() {
-        sut.contentMode = .Redraw
+        sut.contentMode = .redraw
         XCTAssertEqual(sut.hnk_scaleMode, ImageResizer.ScaleMode.None)
     }
     
     func testScaleMode_Center() {
-        sut.contentMode = .Center
+        sut.contentMode = .center
         XCTAssertEqual(sut.hnk_scaleMode, ImageResizer.ScaleMode.None)
     }
     
     func testScaleMode_Top() {
-        sut.contentMode = .Top
+        sut.contentMode = .top
         XCTAssertEqual(sut.hnk_scaleMode, ImageResizer.ScaleMode.None)
     }
     
     func testScaleMode_Bottom() {
-        sut.contentMode = .Bottom
+        sut.contentMode = .bottom
         XCTAssertEqual(sut.hnk_scaleMode, ImageResizer.ScaleMode.None)
     }
     
     func testScaleMode_Left() {
-        sut.contentMode = .Left
+        sut.contentMode = .left
         XCTAssertEqual(sut.hnk_scaleMode, ImageResizer.ScaleMode.None)
     }
     
     func testScaleMode_Right() {
-        sut.contentMode = .Right
+        sut.contentMode = .right
         XCTAssertEqual(sut.hnk_scaleMode, ImageResizer.ScaleMode.None)
     }
     
     func testScaleMode_TopLeft() {
-        sut.contentMode = .TopLeft
+        sut.contentMode = .topLeft
         XCTAssertEqual(sut.hnk_scaleMode, ImageResizer.ScaleMode.None)
     }
     
     func testScaleMode_TopRight() {
-        sut.contentMode = .TopRight
+        sut.contentMode = .topRight
         XCTAssertEqual(sut.hnk_scaleMode, ImageResizer.ScaleMode.None)
     }
     
     func testScaleMode_BottomLeft() {
-        sut.contentMode = .BottomLeft
+        sut.contentMode = .bottomLeft
         XCTAssertEqual(sut.hnk_scaleMode, ImageResizer.ScaleMode.None)
     }
     
     func testScaleMode_BottomRight() {
-        sut.contentMode = .BottomRight
+        sut.contentMode = .bottomRight
         XCTAssertEqual(sut.hnk_scaleMode, ImageResizer.ScaleMode.None)
     }
     
     func testFormatWithSize() {
-        let size = CGSizeMake(10, 20)
+        let size = CGSize(width: 10, height: 20)
         let scaleMode = ImageResizer.ScaleMode.Fill
-        let image = UIImage.imageWithColor(UIColor.redColor())
+        let image = UIImage.imageWithColor(UIColor.red)
         let resizer = ImageResizer(size: size, scaleMode: scaleMode, allowUpscaling: true, compressionQuality: HanekeGlobals.UIKit.DefaultFormat.CompressionQuality)
         
         let format = HanekeGlobals.UIKit.formatWithSize(size, scaleMode: scaleMode)
@@ -110,7 +110,7 @@ class UIImageView_HanekeTests: DiskTestCase {
     func testFormat_Default() {
         let cache = Shared.imageCache
         let resizer = ImageResizer(size: sut.bounds.size, scaleMode: sut.hnk_scaleMode, allowUpscaling: true, compressionQuality: HanekeGlobals.UIKit.DefaultFormat.CompressionQuality)
-        let image = UIImage.imageWithColor(UIColor.greenColor())
+        let image = UIImage.imageWithColor(UIColor.green)
         
         let format = sut.hnk_format
         
@@ -124,7 +124,7 @@ class UIImageView_HanekeTests: DiskTestCase {
     // MARK: setImage
 
     func testSetImage_MemoryMiss() {
-        let image = UIImage.imageWithColor(UIColor.greenColor())
+        let image = UIImage.imageWithColor(UIColor.green)
         let key = self.name!
         
         sut.hnk_setImage(image, key: key)
@@ -134,7 +134,7 @@ class UIImageView_HanekeTests: DiskTestCase {
     }
     
     func testSetImage_MemoryHit() {
-        let image = UIImage.imageWithColor(UIColor.greenColor())
+        let image = UIImage.imageWithColor(UIColor.green)
         let key = self.name!
         let expectedImage = setImage(image, key: key)
         
@@ -145,8 +145,8 @@ class UIImageView_HanekeTests: DiskTestCase {
     }
     
     func testSetImage_ImageSet_MemoryMiss() {
-        let previousImage = UIImage.imageWithColor(UIColor.redColor())
-        let image = UIImage.imageWithColor(UIColor.greenColor())
+        let previousImage = UIImage.imageWithColor(UIColor.red)
+        let image = UIImage.imageWithColor(UIColor.green)
         let key = self.name!
         sut.image = previousImage
         
@@ -157,8 +157,8 @@ class UIImageView_HanekeTests: DiskTestCase {
     }
     
     func testSetImage_UsingPlaceholder_MemoryMiss() {
-        let placeholder = UIImage.imageWithColor(UIColor.yellowColor())
-        let image = UIImage.imageWithColor(UIColor.greenColor())
+        let placeholder = UIImage.imageWithColor(UIColor.yellow)
+        let image = UIImage.imageWithColor(UIColor.green)
         let key = self.name!
         
         sut.hnk_setImage(image, key: key, placeholder: placeholder)
@@ -168,8 +168,8 @@ class UIImageView_HanekeTests: DiskTestCase {
     }
     
     func testSetImage_UsingPlaceholder_MemoryHit() {
-        let placeholder = UIImage.imageWithColor(UIColor.yellowColor())
-        let image = UIImage.imageWithColor(UIColor.greenColor())
+        let placeholder = UIImage.imageWithColor(UIColor.yellow)
+        let image = UIImage.imageWithColor(UIColor.green)
         let key = self.name!
         let expectedImage = setImage(image, key: key)
         
@@ -180,10 +180,10 @@ class UIImageView_HanekeTests: DiskTestCase {
     }
     
     func testSetImage_Success() {
-        let image = UIImage.imageWithColor(UIColor.greenColor())
+        let image = UIImage.imageWithColor(UIColor.green)
         let key = self.name!
-        sut.contentMode = .Center // No resizing
-        let expectation = self.expectationWithDescription(key)
+        sut.contentMode = .center // No resizing
+        let expectation = self.expectation(description: key)
         
         sut.hnk_setImage(image, key: key, success:{resultImage in
             XCTAssertTrue(resultImage.isEqualPixelByPixel(image))
@@ -192,28 +192,28 @@ class UIImageView_HanekeTests: DiskTestCase {
         
         XCTAssertNil(sut.image)
         XCTAssertEqual(sut.hnk_fetcher.key, key)
-        self.waitForExpectationsWithTimeout(1, handler: nil)
+        self.waitForExpectations(timeout: 1, handler: nil)
     }
     
     func testSetImage_UsingFormat() {
-        let image = UIImage.imageWithColor(UIColor.redColor())
-        let expectedImage = UIImage.imageWithColor(UIColor.greenColor())
+        let image = UIImage.imageWithColor(UIColor.red)
+        let expectedImage = UIImage.imageWithColor(UIColor.green)
         let key = self.name!
         let format = Format<UIImage>(name: key, diskCapacity: 0) { _ in return expectedImage }
-        let expectation = self.expectationWithDescription(key)
+        let expectation = self.expectation(description: key)
         
         sut.hnk_setImage(image, key: key, format: format, success:{resultImage in
             XCTAssertTrue(resultImage.isEqualPixelByPixel(expectedImage))
             expectation.fulfill()
         })
         
-        self.waitForExpectationsWithTimeout(1, handler: nil)
+        self.waitForExpectations(timeout: 1, handler: nil)
     }
     
     // MARK: setImageFromFetcher
 
     func testSetImageFromFetcher_MemoryMiss() {
-        let image = UIImage.imageWithColor(UIColor.greenColor())
+        let image = UIImage.imageWithColor(UIColor.green)
         let key = self.name!
         let fetcher = SimpleFetcher<UIImage>(key: key, value: image)
         
@@ -224,7 +224,7 @@ class UIImageView_HanekeTests: DiskTestCase {
     }
     
     func testSetImageFromFetcher_MemoryHit() {
-        let image = UIImage.imageWithColor(UIColor.greenColor())
+        let image = UIImage.imageWithColor(UIColor.green)
         let key = self.name!
         let fetcher = SimpleFetcher<UIImage>(key: key, value: image)
         let expectedImage = setImage(image, key: key)
@@ -236,7 +236,7 @@ class UIImageView_HanekeTests: DiskTestCase {
     }
 
     func testSetImageFromFetcher_Hit_Animated() {
-        let image = UIImage.imageWithColor(UIColor.greenColor())
+        let image = UIImage.imageWithColor(UIColor.green)
         let key = self.name!
         let fetcher = AsyncFetcher<UIImage>(key: key, value: image)
         let expectedImage = sut.hnk_format.apply(image)
@@ -254,8 +254,8 @@ class UIImageView_HanekeTests: DiskTestCase {
     }
     
     func testSetImageFromFetcher_ImageSet_MemoryMiss() {
-        let previousImage = UIImage.imageWithColor(UIColor.redColor())
-        let image = UIImage.imageWithColor(UIColor.greenColor())
+        let previousImage = UIImage.imageWithColor(UIColor.red)
+        let image = UIImage.imageWithColor(UIColor.green)
         let key = self.name!
         let fetcher = SimpleFetcher<UIImage>(key: key, value: image)
         sut.image = previousImage
@@ -267,8 +267,8 @@ class UIImageView_HanekeTests: DiskTestCase {
     }
 
     func testSetImageFromFetcher_UsingPlaceholder_MemoryMiss() {
-        let placeholder = UIImage.imageWithColor(UIColor.yellowColor())
-        let image = UIImage.imageWithColor(UIColor.greenColor())
+        let placeholder = UIImage.imageWithColor(UIColor.yellow)
+        let image = UIImage.imageWithColor(UIColor.green)
         let key = self.name!
         let fetcher = SimpleFetcher<UIImage>(key: key, value: image)
         
@@ -279,8 +279,8 @@ class UIImageView_HanekeTests: DiskTestCase {
     }
     
     func testSetImageFromFetcher_UsingPlaceholder_MemoryHit() {
-        let placeholder = UIImage.imageWithColor(UIColor.yellowColor())
-        let image = UIImage.imageWithColor(UIColor.greenColor())
+        let placeholder = UIImage.imageWithColor(UIColor.yellow)
+        let image = UIImage.imageWithColor(UIColor.green)
         let key = self.name!
         let fetcher = SimpleFetcher<UIImage>(key: key, value: image)
         let expectedImage = setImage(image, key: key)
@@ -292,11 +292,11 @@ class UIImageView_HanekeTests: DiskTestCase {
     }
     
     func testSetImageFromFetcher_Success() {
-        let image = UIImage.imageWithColor(UIColor.greenColor())
+        let image = UIImage.imageWithColor(UIColor.green)
         let key = self.name!
         let fetcher = SimpleFetcher<UIImage>(key: key, value: image)
-        sut.contentMode = .Center // No resizing
-        let expectation = self.expectationWithDescription(key)
+        sut.contentMode = .center // No resizing
+        let expectation = self.expectation(description: key)
         
         sut.hnk_setImageFromFetcher(fetcher, success: { resultImage in
             XCTAssertTrue(resultImage.isEqualPixelByPixel(image))
@@ -305,13 +305,13 @@ class UIImageView_HanekeTests: DiskTestCase {
         
         XCTAssertNil(sut.image)
         XCTAssertTrue(sut.hnk_fetcher === fetcher)
-        self.waitForExpectationsWithTimeout(1, handler: nil)
+        self.waitForExpectations(timeout: 1, handler: nil)
     }
     
     func testSetImageFromFetcher_Failure() {
         let key = self.name!
         let fetcher = MockFetcher<UIImage>(key: key)
-        let expectation = self.expectationWithDescription(key)
+        let expectation = self.expectation(description: key)
         
         sut.hnk_setImageFromFetcher(fetcher, failure: {error in
             XCTAssertEqual(error!.domain, HanekeGlobals.Domain)
@@ -320,23 +320,23 @@ class UIImageView_HanekeTests: DiskTestCase {
         
         XCTAssertNil(sut.image)
         XCTAssertTrue(sut.hnk_fetcher === fetcher)
-        self.waitForExpectationsWithTimeout(1, handler: nil)
+        self.waitForExpectations(timeout: 1, handler: nil)
     }
     
     func testSetImageFromFetcher_UsingFormat() {
-        let image = UIImage.imageWithColor(UIColor.redColor())
-        let expectedImage = UIImage.imageWithColor(UIColor.greenColor())
+        let image = UIImage.imageWithColor(UIColor.red)
+        let expectedImage = UIImage.imageWithColor(UIColor.green)
         let key = self.name!
         let format = Format<UIImage>(name: key, diskCapacity: 0) { _ in return expectedImage }
         let fetcher = SimpleFetcher<UIImage>(key: key, value: image)
-        let expectation = self.expectationWithDescription(key)
+        let expectation = self.expectation(description: key)
         
         sut.hnk_setImageFromFetcher(fetcher, format: format, success: { resultImage in
             XCTAssertTrue(resultImage.isEqualPixelByPixel(expectedImage))
             expectation.fulfill()
         })
         
-        self.waitForExpectationsWithTimeout(1, handler: nil)
+        self.waitForExpectations(timeout: 1, handler: nil)
     }
     
     // MARK: setImageFromFile
@@ -351,7 +351,7 @@ class UIImageView_HanekeTests: DiskTestCase {
     }
     
     func testSetImageFromFile_MemoryHit() {
-        let image = UIImage.imageWithColor(UIColor.orangeColor())
+        let image = UIImage.imageWithColor(UIColor.orange)
         let fetcher = DiskFetcher<UIImage>(path: self.uniquePath())
         let expectedImage = setImage(image, key: fetcher.key)
         
@@ -362,7 +362,7 @@ class UIImageView_HanekeTests: DiskTestCase {
     }
     
     func testSetImageFromFileSuccessFailure_MemoryHit() {
-        let image = UIImage.imageWithColor(UIColor.greenColor())
+        let image = UIImage.imageWithColor(UIColor.green)
         let fetcher = DiskFetcher<UIImage>(path: self.uniquePath())
         let expectedImage = setImage(image, key: fetcher.key)
         
@@ -376,7 +376,7 @@ class UIImageView_HanekeTests: DiskTestCase {
     // MARK: setImageFromURL
     
     func testSetImageFromURL_MemoryMiss() {
-        let URL = NSURL(string: "http://haneke.io")!
+        let URL = Foundation.URL(string: "http://haneke.io")!
         let fetcher = NetworkFetcher<UIImage>(URL: URL)
         
         sut.hnk_setImageFromURL(URL)
@@ -386,8 +386,8 @@ class UIImageView_HanekeTests: DiskTestCase {
     }
     
     func testSetImageFromURL_MemoryHit() {
-        let image = UIImage.imageWithColor(UIColor.greenColor())
-        let URL = NSURL(string: "http://haneke.io")!
+        let image = UIImage.imageWithColor(UIColor.green)
+        let URL = Foundation.URL(string: "http://haneke.io")!
         let fetcher = NetworkFetcher<UIImage>(URL: URL)
         let expectedImage = setImage(image, key: fetcher.key)
         
@@ -398,8 +398,8 @@ class UIImageView_HanekeTests: DiskTestCase {
     }
     
     func testSetImageFromURL_ImageSet_MemoryMiss() {
-        let previousImage = UIImage.imageWithColor(UIColor.redColor())
-        let URL = NSURL(string: "http://haneke.io")!
+        let previousImage = UIImage.imageWithColor(UIColor.red)
+        let URL = Foundation.URL(string: "http://haneke.io")!
         let fetcher = NetworkFetcher<UIImage>(URL: URL)
         sut.image = previousImage
         
@@ -410,8 +410,8 @@ class UIImageView_HanekeTests: DiskTestCase {
     }
     
     func testSetImageFromURL_UsingPlaceholder_MemoryMiss() {
-        let placeholder = UIImage.imageWithColor(UIColor.yellowColor())
-        let URL = NSURL(string: "http://haneke.io")!
+        let placeholder = UIImage.imageWithColor(UIColor.yellow)
+        let URL = Foundation.URL(string: "http://haneke.io")!
         let fetcher = NetworkFetcher<UIImage>(URL: URL)
         
         sut.hnk_setImageFromURL(URL, placeholder: placeholder)
@@ -421,9 +421,9 @@ class UIImageView_HanekeTests: DiskTestCase {
     }
     
     func testSetImageFromURL_UsingPlaceholder_MemoryHit() {
-        let placeholder = UIImage.imageWithColor(UIColor.yellowColor())
-        let image = UIImage.imageWithColor(UIColor.greenColor())
-        let URL = NSURL(string: "http://haneke.io")!
+        let placeholder = UIImage.imageWithColor(UIColor.yellow)
+        let image = UIImage.imageWithColor(UIColor.green)
+        let URL = Foundation.URL(string: "http://haneke.io")!
         let fetcher = NetworkFetcher<UIImage>(URL: URL)
         let expectedImage = setImage(image, key: fetcher.key)
         
@@ -434,17 +434,17 @@ class UIImageView_HanekeTests: DiskTestCase {
     }
     
     func testSetImageFromURL_Success() {
-        let image = UIImage.imageWithColor(UIColor.greenColor())
+        let image = UIImage.imageWithColor(UIColor.green)
         OHHTTPStubs.stubRequestsPassingTest({ _ in
             return true
             }, withStubResponse: { _ in
                 let data = UIImagePNGRepresentation(image)
                 return OHHTTPStubsResponse(data: data!, statusCode: 200, headers:nil)
         })
-        let URL = NSURL(string: "http://haneke.io")!
+        let URL = Foundation.URL(string: "http://haneke.io")!
         let fetcher = NetworkFetcher<UIImage>(URL: URL)
-        sut.contentMode = .Center // No resizing
-        let expectation = self.expectationWithDescription(self.name!)
+        sut.contentMode = .center // No resizing
+        let expectation = self.expectation(description: self.name!)
         
         sut.hnk_setImageFromURL(URL, success:{resultImage in
             XCTAssertTrue(resultImage.isEqualPixelByPixel(image))
@@ -453,27 +453,27 @@ class UIImageView_HanekeTests: DiskTestCase {
         
         XCTAssertNil(sut.image)
         XCTAssertEqual(sut.hnk_fetcher.key, fetcher.key)
-        self.waitForExpectationsWithTimeout(1, handler: nil)
+        self.waitForExpectations(timeout: 1, handler: nil)
     }
     
     func testSetImageFromURL_WhenPreviousSetImageFromURL() {
-        let image = UIImage.imageWithColor(UIColor.greenColor())
+        let image = UIImage.imageWithColor(UIColor.green)
         OHHTTPStubs.stubRequestsPassingTest({ _ in
             return true
             }, withStubResponse: { _ in
                 let data = UIImagePNGRepresentation(image)
                 return OHHTTPStubsResponse(data: data!, statusCode: 200, headers:nil).responseTime(0.1)
         })
-        let URL1 = NSURL(string: "http://haneke.io/1.png")!
-        sut.contentMode = .Center // No resizing
+        let URL1 = URL(string: "http://haneke.io/1.png")!
+        sut.contentMode = .center // No resizing
         sut.hnk_setImageFromURL(URL1, success:{_ in
             XCTFail("unexpected success")
             }, failure:{_ in
             XCTFail("unexpected failure")
         })
-        let URL2 = NSURL(string: "http://haneke.io/2.png")!
+        let URL2 = URL(string: "http://haneke.io/2.png")!
         let fetcher2 = NetworkFetcher<UIImage>(URL: URL2)
-        let expectation = self.expectationWithDescription(self.name!)
+        let expectation = self.expectation(description: self.name!)
         
         sut.hnk_setImageFromURL(URL2, success:{resultImage in
             XCTAssertTrue(resultImage.isEqualPixelByPixel(image))
@@ -482,19 +482,19 @@ class UIImageView_HanekeTests: DiskTestCase {
         
         XCTAssertNil(sut.image)
         XCTAssertEqual(sut.hnk_fetcher.key, fetcher2.key)
-        self.waitForExpectationsWithTimeout(1, handler: nil)
+        self.waitForExpectations(timeout: 1, handler: nil)
     }
     
     func testSetImageFromURL_Failure() {
         OHHTTPStubs.stubRequestsPassingTest({ _ in
             return true
             }, withStubResponse: { _ in
-                let data = NSData.dataWithLength(100)
+                let data = Data.dataWithLength(100)
                 return OHHTTPStubsResponse(data: data, statusCode: 404, headers:nil)
         })
-        let URL = NSURL(string: "http://haneke.io")!
+        let URL = Foundation.URL(string: "http://haneke.io")!
         let fetcher = NetworkFetcher<UIImage>(URL: URL)
-        let expectation = self.expectationWithDescription(self.name!)
+        let expectation = self.expectation(description: self.name!)
         
         sut.hnk_setImageFromURL(URL, failure:{error in
             XCTAssertEqual(error!.domain, HanekeGlobals.Domain)
@@ -503,12 +503,12 @@ class UIImageView_HanekeTests: DiskTestCase {
         
         XCTAssertNil(sut.image)
         XCTAssertEqual(sut.hnk_fetcher.key, fetcher.key)
-        self.waitForExpectationsWithTimeout(1, handler: nil)
+        self.waitForExpectations(timeout: 1, handler: nil)
     }
 
     func testSetImageFromURL_UsingFormat() {
-        let image = UIImage.imageWithColor(UIColor.redColor())
-        let expectedImage = UIImage.imageWithColor(UIColor.greenColor())
+        let image = UIImage.imageWithColor(UIColor.red)
+        let expectedImage = UIImage.imageWithColor(UIColor.green)
         let format = Format<UIImage>(name: self.name!, diskCapacity: 0) { _ in return expectedImage }
         OHHTTPStubs.stubRequestsPassingTest({ _ in
             return true
@@ -516,15 +516,15 @@ class UIImageView_HanekeTests: DiskTestCase {
                 let data = UIImagePNGRepresentation(image)
                 return OHHTTPStubsResponse(data: data!, statusCode: 200, headers:nil)
         })
-        let URL = NSURL(string: "http://haneke.io")!
-        let expectation = self.expectationWithDescription(self.name!)
+        let URL = Foundation.URL(string: "http://haneke.io")!
+        let expectation = self.expectation(description: self.name!)
         
         sut.hnk_setImageFromURL(URL, format: format, success:{resultImage in
             XCTAssertTrue(resultImage.isEqualPixelByPixel(expectedImage))
             expectation.fulfill()
         })
         
-        self.waitForExpectationsWithTimeout(1, handler: nil)
+        self.waitForExpectations(timeout: 1, handler: nil)
     }
     
     // MARK: cancelSetImage
@@ -536,7 +536,7 @@ class UIImageView_HanekeTests: DiskTestCase {
     }
     
     func testCancelSetImage_AfterSetImage() {
-        let URL = NSURL(string: "http://imgs.xkcd.com/comics/election.png")!
+        let URL = Foundation.URL(string: "http://imgs.xkcd.com/comics/election.png")!
         sut.hnk_setImageFromURL(URL, success: { _ in
             XCTFail("unexpected success")
         }, failure: { _ in
@@ -551,16 +551,16 @@ class UIImageView_HanekeTests: DiskTestCase {
     
     // MARK: Helpers
     
-    func setImage(image : UIImage, key: String) -> UIImage {
+    func setImage(_ image : UIImage, key: String) -> UIImage {
         let format = sut.hnk_format
         let expectedImage = format.apply(image)
         let cache = Shared.imageCache
         cache.addFormat(format)
-        let expectation = self.expectationWithDescription("set")
+        let expectation = self.expectation(description: "set")
         cache.set(value: image, key: key, formatName: format.name) { _ in
             expectation.fulfill()
         }
-        self.waitForExpectationsWithTimeout(1, handler: nil)
+        self.waitForExpectations(timeout: 1, handler: nil)
         return expectedImage
     }
 
@@ -572,7 +572,7 @@ class MockFetcher<T : DataConvertible> : Fetcher<T> {
         super.init(key: key)
     }
     
-    override func fetch(failure fail : ((NSError?) -> ()), success succeed : (T.Result) -> ()) {
+    override func fetch(failure fail : ((Error?) -> ()), success succeed : (T.Result) -> ()) {
         let error = errorWithCode(0, description: "test")
         fail(error)
     }

--- a/HanekeTests/XCTestCase+Test.swift
+++ b/HanekeTests/XCTestCase+Test.swift
@@ -10,18 +10,18 @@ import XCTest
 
 extension XCTestCase {
     
-    func waitFor(interval : NSTimeInterval) {
-        let date = NSDate(timeIntervalSinceNow: interval)
-        NSRunLoop.currentRunLoop().runMode(NSDefaultRunLoopMode, beforeDate: date)
+    func waitFor(_ interval : TimeInterval) {
+        let date = Date(timeIntervalSinceNow: interval)
+        RunLoop.current.run(mode: Mode.defaultRunLoopMode, before: date)
     }
 
-    func wait(timeout : NSTimeInterval, condition: () -> Bool) {
-        let timeoutDate = NSDate(timeIntervalSinceNow: timeout)
+    func wait(_ timeout : TimeInterval, condition: () -> Bool) {
+        let timeoutDate = Date(timeIntervalSinceNow: timeout)
         var success = false
-        while !success && NSDate().laterDate(timeoutDate).isEqualToDate(timeoutDate) {
+        while !success && (Date().laterDate(timeoutDate) == timeoutDate) {
             success = condition()
             if !success {
-                NSRunLoop.currentRunLoop().runMode(NSDefaultRunLoopMode, beforeDate: timeoutDate)
+                RunLoop.current.run(mode: Mode.defaultRunLoopMode, before: timeoutDate)
             }
         }
         if !success {


### PR DESCRIPTION
Some methods such as `pathForKey(key: String)` have been changed to `path(forKey key: String)`

Changed name of `Cache` class to `HanekeCache` in order to not conflict with potential Swift3 `Cache` class which stems from `NSCache`