### PR TITLE
Swift 2.3 support

### DIFF
--- a/Haneke.xcodeproj/project.pbxproj
+++ b/Haneke.xcodeproj/project.pbxproj
@@ -484,14 +484,19 @@
 				LastUpgradeCheck = 0700;
 				ORGANIZATIONNAME = Haneke;
 				TargetAttributes = {
+					6393C5DA1C3B229200EB1FD8 = {
+						LastSwiftMigration = 0800;
+					};
 					A0026E9919C9BFBC004DE0C6 = {
 						CreatedOnToolsVersion = 6.0;
 					};
 					A095C9551980418C00CD0F4C = {
 						CreatedOnToolsVersion = 6.0;
+						LastSwiftMigration = 0800;
 					};
 					A095C9601980418C00CD0F4C = {
 						CreatedOnToolsVersion = 6.0;
+						LastSwiftMigration = 0800;
 						TestTargetID = A095C9551980418C00CD0F4C;
 					};
 				};
@@ -719,6 +724,7 @@
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 2.3;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 			};
@@ -740,6 +746,7 @@
 				PRODUCT_NAME = Haneke;
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 2.3;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 			};
@@ -873,6 +880,7 @@
 				PRODUCT_NAME = Haneke;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 2.3;
 			};
 			name = Debug;
 		};
@@ -891,6 +899,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = io.haneke.Haneke;
 				PRODUCT_NAME = Haneke;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 2.3;
 			};
 			name = Release;
 		};
@@ -913,6 +922,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "HanekeTests/HanekeTests-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 2.3;
 			};
 			name = Debug;
 		};
@@ -930,6 +940,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "io.haneke.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "HanekeTests/HanekeTests-Bridging-Header.h";
+				SWIFT_VERSION = 2.3;
 			};
 			name = Release;
 		};

--- a/Haneke/NetworkFetcher.swift
+++ b/Haneke/NetworkFetcher.swift
@@ -31,7 +31,7 @@ public class NetworkFetcher<T : DataConvertible> : Fetcher<T> {
         self.URL = URL
 
         let key =  URL.absoluteString
-        super.init(key: key)
+        super.init(key: key!)
     }
     
     public var session : NSURLSession { return NSURLSession.sharedSession() }
@@ -88,7 +88,7 @@ public class NetworkFetcher<T : DataConvertible> : Fetcher<T> {
         
         guard let value = T.convertFromData(data) else {
             let localizedFormat = NSLocalizedString("Failed to convert value from data at URL %@", comment: "Error description")
-            let description = String(format:localizedFormat, URL.absoluteString)
+            let description = String(format:localizedFormat, URL.description)
             self.failWithCode(.InvalidData, localizedDescription: description, failure: fail)
             return
         }

--- a/Haneke/UIImage+Haneke.swift
+++ b/Haneke/UIImage+Haneke.swift
@@ -10,7 +10,7 @@ import UIKit
 
 extension UIImage {
 
-    func hnk_imageByScalingToSize(toSize: CGSize) -> UIImage {
+    func hnk_imageByScalingToSize(toSize: CGSize) -> UIImage! {
         UIGraphicsBeginImageContextWithOptions(toSize, !hnk_hasAlpha(), 0.0)
         drawInRect(CGRectMake(0, 0, toSize.width, toSize.height))
         let resizedImage = UIGraphicsGetImageFromCurrentImageContext()
@@ -19,7 +19,7 @@ extension UIImage {
     }
 
     func hnk_hasAlpha() -> Bool {
-        let alpha = CGImageGetAlphaInfo(self.CGImage)
+        let alpha = CGImageGetAlphaInfo(self.CGImage!)
         switch alpha {
         case .First, .Last, .PremultipliedFirst, .PremultipliedLast, .Only:
             return true
@@ -36,8 +36,8 @@ extension UIImage {
     
     func hnk_decompressedImage() -> UIImage! {
         let originalImageRef = self.CGImage
-        let originalBitmapInfo = CGImageGetBitmapInfo(originalImageRef)
-        let alphaInfo = CGImageGetAlphaInfo(originalImageRef)
+        let originalBitmapInfo = CGImageGetBitmapInfo(originalImageRef!)
+        let alphaInfo = CGImageGetAlphaInfo(originalImageRef!)
         
         // See: http://stackoverflow.com/questions/23723564/which-cgimagealphainfo-should-we-use
         var bitmapInfo = originalBitmapInfo
@@ -54,7 +54,7 @@ extension UIImage {
         
         let colorSpace = CGColorSpaceCreateDeviceRGB()
         let pixelSize = CGSizeMake(self.size.width * self.scale, self.size.height * self.scale)
-        guard let context = CGBitmapContextCreate(nil, Int(ceil(pixelSize.width)), Int(ceil(pixelSize.height)), CGImageGetBitsPerComponent(originalImageRef), 0, colorSpace, bitmapInfo.rawValue) else {
+        guard let context = CGBitmapContextCreate(nil, Int(ceil(pixelSize.width)), Int(ceil(pixelSize.height)), CGImageGetBitsPerComponent(originalImageRef!), 0, colorSpace, bitmapInfo.rawValue) else {
             return self
         }
 


### PR DESCRIPTION
I've made a branch to support Swift 2.3.  The changes were pretty minor.  You may want to take a look at the `UIImage+Haneke` changes, as they involve some force unwrapping, and I wasn't sure how you thought this should be handled (might require changing the method signature).

I'm guess that you will not want to `master`, but if you would like to create a `swift-2.3` branch, I can close this and submit a new PR pointing there.

This should address #331.