### PR TITLE
Explicitly set Provisioning Style to Automatic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ branches:
     - master
     - feature/swift-3
 script:
-  - set -o pipefail && xcodebuild -workspace Haneke.xcworkspace -scheme Haneke-iOS -sdk iphonesimulator10.0 build test | xcpretty --color
+  - set -o pipefail && xcodebuild -workspace Haneke.xcworkspace -scheme Haneke-iOS -destination 'platform=iOS Simulator,name=iPhone 6,OS=9.3' build test | xcpretty --color

--- a/Haneke.xcodeproj/project.pbxproj
+++ b/Haneke.xcodeproj/project.pbxproj
@@ -486,6 +486,7 @@
 				TargetAttributes = {
 					6393C5DA1C3B229200EB1FD8 = {
 						LastSwiftMigration = 0800;
+						ProvisioningStyle = Automatic;
 					};
 					A0026E9919C9BFBC004DE0C6 = {
 						CreatedOnToolsVersion = 6.0;
@@ -714,7 +715,9 @@
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "iPhone Developer";
 				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -737,7 +740,9 @@
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "iPhone Developer";
 				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";

--- a/Haneke.xcodeproj/project.pbxproj
+++ b/Haneke.xcodeproj/project.pbxproj
@@ -494,6 +494,7 @@
 					A095C9551980418C00CD0F4C = {
 						CreatedOnToolsVersion = 6.0;
 						LastSwiftMigration = 0800;
+						ProvisioningStyle = Automatic;
 					};
 					A095C9601980418C00CD0F4C = {
 						CreatedOnToolsVersion = 6.0;
@@ -872,7 +873,9 @@
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -892,7 +895,9 @@
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";


### PR DESCRIPTION
This PR explicitly set the Provisioning Style to Automatic in the iOS and tvOS targets. Xcode 8 changed the way code sign works, and having the style explicitly set in the project file can help with scripts.

This has been done by simply unchecking and checking again the checkbox on the General tab.

I didn't open an issue to suggest this change because it's super easy to implement anyway. If you don't find it valuable feel free to close the PR  ¯_(ツ)_/¯.

Cheers
