### PR TITLE
Publicize the Cache.formats var

### DIFF
--- a/Haneke/Cache.swift
+++ b/Haneke/Cache.swift
@@ -177,7 +177,7 @@ public class Cache<T: DataConvertible where T.Result == T, T : DataRepresentable
     
     // MARK: Formats
 
-    var formats : [String : (Format<T>, NSCache, DiskCache)] = [:]
+    public var formats : [String : (Format<T>, NSCache, DiskCache)] = [:]
     
     public func addFormat(format : Format<T>) {
         let name = format.name


### PR DESCRIPTION
The README mentions that you can set your own format like so (to ensure that you only add it once without overwriting it):

```
HNKCacheFormat *format = [HNKCache sharedCache].formats[@"thumbnail"];
if (!format)
{
    format = [[HNKCacheFormat alloc] initWithName:@"thumbnail"];
    format.size = CGSizeMake(320, 240);
    format.scaleMode = HNKScaleModeAspectFill;
    format.compressionQuality = 0.5;
    format.diskCapacity = 1 * 1024 * 1024; // 1MB
    format.preloadPolicy = HNKPreloadPolicyLastSession;
}
imageView.hnk_cacheFormat = format;
```

This doesn't work in Swift, because the `formats` var is not `public`. This PR does just that.

This PR is a successor to the closed https://github.com/Haneke/HanekeSwift/pull/352 PR.