### PR TITLE
Made formats public in cache like on the master branch

### DIFF
--- a/Haneke/Cache.swift
+++ b/Haneke/Cache.swift
@@ -177,7 +177,7 @@ open class Cache<T: DataConvertible> where T.Result == T, T : DataRepresentable 
     
     // MARK: Formats
 
-    var formats : [String : (Format<T>, NSCache<AnyObject, AnyObject>, DiskCache)] = [:]
+    public var formats : [String : (Format<T>, NSCache<AnyObject, AnyObject>, DiskCache)] = [:]
     
     open func addFormat(_ format : Format<T>) {
         let name = format.name


### PR DESCRIPTION
Changed the cache.swift variable formats to public so that it matches the master branch