### PR TITLE
URL.absoluteString isn't optional

### DIFF
--- a/Haneke/NetworkFetcher.swift
+++ b/Haneke/NetworkFetcher.swift
@@ -31,7 +31,7 @@ open class NetworkFetcher<T : DataConvertible> : Fetcher<T> {
         self.URL = URL
 
         let key =  URL.absoluteString
-        super.init(key: key!)
+        super.init(key: key)
     }
     
     open var session : URLSession { return URLSession.shared }


### PR DESCRIPTION
Related to #390 

```
NetworkFetcher.swift:34:28: error: cannot force unwrap value of non-optional type 'String'
        super.init(key: key!)
```

