### PR TITLE
Fix intermittent build failures on Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ branches:
     - master
     - feature/swift-3
 script:
-  - set -o pipefail && xcodebuild -workspace Haneke.xcworkspace -scheme Haneke-iOS -sdk iphonesimulator10.3 -destination 'platform=iOS Simulator,name=iPhone 7 Plus,OS=10.3' build test | xcpretty --color
+  - set -o pipefail && xcodebuild -workspace Haneke.xcworkspace -scheme Haneke-iOS -sdk iphonesimulator10.3 -destination 'platform=iOS Simulator,name=iPhone 7 Plus,OS=10.3' build test CODE_SIGNING_REQUIRED=NO | xcpretty --color


### PR DESCRIPTION
According to [a Stack Overflow post](http://stackoverflow.com/questions/27671854/travis-ci-fails-to-build-with-a-code-signing-error), adding `CODE_SIGNING_REQUIRED=NO` to the Travis-CI script should fix the CI failures that branches based on `feature/swift-3` are sometimes having.