### PR TITLE
Fix intermitent CI failure by sleeping after test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,5 @@ branches:
     - feature/swift-3
 script:
   - set -o pipefail && xcodebuild -workspace Haneke.xcworkspace -scheme Haneke-iOS -sdk iphonesimulator10.3 -destination 'platform=iOS Simulator,name=iPhone 7 Plus,OS=10.3' build test CODE_SIGNING_REQUIRED=NO | xcpretty --color
+after_success:
+  - sleep 5 # https://github.com/travis-ci/travis-ci/issues/4725


### PR DESCRIPTION
One more try at #393.

Builds have been failing due to what seems to be a timeout issue in Travis-CI. An example of a failing build is [the most recent `feature/swift-3` merge](https://travis-ci.org/Haneke/HanekeSwift/builds/221467543).

As recommended in travis-ci/travis-ci#4725, I've attempted to fix this issue by sleeping the CI server for a few seconds after running the test script.