### PR TITLE
Experiment with CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,4 @@ branches:
     - master
     - feature/swift-3
 script:
-  - set -o pipefail && xcodebuild -workspace Haneke.xcworkspace -scheme Haneke-iOS -sdk iphonesimulator10.3 -destination 'platform=iOS Simulator,name=iPhone 7 Plus,OS=10.3' build test CODE_SIGNING_REQUIRED=NO | xcpretty --color
-after_success:
-  - sleep 5 # https://github.com/travis-ci/travis-ci/issues/4725
+  - set -o pipefail && xcodebuild build test -workspace Haneke.xcworkspace -scheme Haneke-iOS -destination 'platform=iOS Simulator,name=iPhone SE,OS=10.3' | xcpretty --color


### PR DESCRIPTION
Test on iPhone SE simulator and disallow code signing to attempt to solve CI issues. Removing `sleep` as it doesn't seem to help.

First attempt followed advice from user werner77 in travis-ci/travis-ci#6422, running separate `build-for-testing` and `test-without-building` steps to help prevent Travis-CI timing out. This didn't help. Also tried prelaunching simulator based on advice by user cotsog, which also didn't help.