### PR TITLE
Increment podspec version to 0.11.0

### DIFF
--- a/HanekeSwift.podspec
+++ b/HanekeSwift.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name = 'HanekeSwift'
   s.module_name = 'Haneke'
-  s.version = '0.10.1'
+  s.version = '0.11.0'
   s.license = 'Apache'
   s.summary = 'A lightweight generic cache for iOS written in Swift with extra love for images.'
   s.homepage = 'https://github.com/Haneke/HanekeSwift'


### PR DESCRIPTION
HanekeSwift should release a new version to CocoaPods, so that users with the `README.md`-recommended `pod 'HanekeSwift'` line in their `Podfile` will see the latest Swift 3 changes.

As I commented on #379, the following steps are necessary to release a new version to CocoaPods:

- [ ] Update s.version to 0.11.0 in HanekeSwift.podspec and validate by running pod lib lint
  - Merging this PR will complete this step
- [ ] [Create a tag](https://github.com/Haneke/HanekeSwift/releases) `0.11.0` on GitHub
  - Any maintainer of this GitHub repo, like @dcharbonnier, can complete this step once this PR is merged
- [ ] [Publish to CocoaPods](https://guides.cocoapods.org/making/making-a-cocoapod.html#release) by running `pod trunk push HanekeSwift.podspec`
  - Only @hpique can complete this final step
  - Alternatively, @hpique can [register another contributor with CocoaPods](https://guides.cocoapods.org/making/getting-setup-with-trunk#adding-other-people-as-contributors), and that new contributor can complete this final step

Completing these three steps will satisfy #397.