### PR TITLE
Add path in DiskCache callback

### DIFF
--- a/Haneke/DiskCache.swift
+++ b/Haneke/DiskCache.swift
@@ -55,13 +55,13 @@ open class DiskCache {
         })
     }
     
-    open func fetchData(key: String, failure fail: ((Error?) -> ())? = nil, success succeed: @escaping (Data) -> ()) {
+    open func fetchData(key: String, failure fail: ((Error?) -> ())? = nil, success succeed: @escaping (Data, String) -> ()) {
         cacheQueue.async {
             let path = self.path(forKey: key)
             do {
                 let data = try Data(contentsOf: URL(fileURLWithPath: path), options: Data.ReadingOptions())
                 DispatchQueue.main.async {
-                    succeed(data)
+                    succeed(data, path)
                 }
                 self.updateDiskAccessDate(atPath: path)
             } catch {

--- a/Haneke/Fetch.swift
+++ b/Haneke/Fetch.swift
@@ -19,7 +19,7 @@ enum FetchState<T> {
 
 open class Fetch<T> {
     
-    public typealias Succeeder = (T) -> ()
+    public typealias Succeeder = (T, String?) -> ()
     
     public typealias Failer = (Error?) -> ()
     
@@ -31,11 +31,11 @@ open class Fetch<T> {
     
     public init() {}
     
-    @discardableResult open func onSuccess(_ onSuccess: @escaping Succeeder) -> Self {
+    @discardableResult open func onSuccess(_ onSuccess: @escaping Succeeder, path: String? = nil) -> Self {
         self.onSuccess = onSuccess
         switch self.state {
         case FetchState.success(let wrapper):
-            onSuccess(wrapper.value)
+            onSuccess(wrapper.value, path)
         default:
             break
         }
@@ -53,9 +53,9 @@ open class Fetch<T> {
         return self
     }
     
-    func succeed(_ value: T) {
+    func succeed(_ value: T, path: String? = nil) {
         self.state = FetchState.success(Wrapper(value))
-        self.onSuccess?(value)
+        self.onSuccess?(value, path)
     }
     
     func fail(_ error: Error? = nil) {

--- a/Haneke/UIButton+Haneke.swift
+++ b/Haneke/UIButton+Haneke.swift
@@ -89,7 +89,7 @@ public extension UIButton {
                 
                 fail?(error)
             }
-            }) { [weak self] image in
+            }) { [weak self] image, path in
                 if let strongSelf = self {
                     if strongSelf.hnk_shouldCancelImageForKey(fetcher.key) { return }
                     
@@ -200,7 +200,7 @@ public extension UIButton {
                 
                 fail?(error)
             }
-            }) { [weak self] image in
+            }) { [weak self] image, path in
                 if let strongSelf = self {
                     if strongSelf.hnk_shouldCancelBackgroundImageForKey(fetcher.key) { return }
                     

--- a/Haneke/UIImageView+Haneke.swift
+++ b/Haneke/UIImageView+Haneke.swift
@@ -104,7 +104,7 @@ public extension UIImageView {
                 
                 fail?(error)
             }
-        }) { [weak self] image in
+        }) { [weak self] image, path in
             if let strongSelf = self {
                 if strongSelf.hnk_shouldCancel(forKey: fetcher.key) { return }
                 

--- a/HanekeSwift.podspec
+++ b/HanekeSwift.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name = 'HanekeSwift'
   s.module_name = 'Haneke'
-  s.version = '0.10.1'
+  s.version = '0.11.0'
   s.license = 'Apache'
   s.summary = 'A lightweight generic cache for iOS written in Swift with extra love for images.'
   s.homepage = 'https://github.com/Haneke/HanekeSwift'


### PR DESCRIPTION
In some cases, we need to use local cache path in callback, to avoid re-create file. 
