### PR TITLE
[FIX] #112 Crash about an optional

### DIFF
--- a/Haneke/NetworkFetcher.swift
+++ b/Haneke/NetworkFetcher.swift
@@ -31,7 +31,7 @@ open class NetworkFetcher<T : DataConvertible> : Fetcher<T> {
         self.URL = URL
 
         let key =  URL.absoluteString
-        super.init(key: key!)
+        super.init(key: key)
     }
     
     open var session : URLSession { return URLSession.shared }

--- a/Haneke/UIImage+Haneke.swift
+++ b/Haneke/UIImage+Haneke.swift
@@ -13,9 +13,12 @@ extension UIImage {
     func hnk_imageByScaling(toSize size: CGSize) -> UIImage {
         UIGraphicsBeginImageContextWithOptions(size, !hnk_hasAlpha(), 0.0)
         draw(in: CGRect(x: 0, y: 0, width: size.width, height: size.height))
-        let resizedImage = UIGraphicsGetImageFromCurrentImageContext()
-        UIGraphicsEndImageContext()
-        return resizedImage!
+		if let resizedImage = UIGraphicsGetImageFromCurrentImageContext() {
+			UIGraphicsEndImageContext()
+			return resizedImage
+		} else {
+			return self
+		}
     }
 
     func hnk_hasAlpha() -> Bool {


### PR DESCRIPTION
Fix a possible crash when UIGraphicsGetImageFromCurrentImageContext return nil