### PR TITLE
Fixes an Issue with Optionals in the Scaling function

### DIFF
--- a/Haneke/UIImage+Haneke.swift
+++ b/Haneke/UIImage+Haneke.swift
@@ -15,7 +15,7 @@ extension UIImage {
         draw(in: CGRect(x: 0, y: 0, width: size.width, height: size.height))
         let resizedImage = UIGraphicsGetImageFromCurrentImageContext()
         UIGraphicsEndImageContext()
-        return resizedImage!
+        return resizedImage ?? self;
     }
 
     func hnk_hasAlpha() -> Bool {


### PR DESCRIPTION
Currently, the hnk_imageByScaling() function assumes the successful creation of an image context. But in reality, with some image sizes, this will fail so this case should be handled

Another way to resolve this would be for applications to check for odd image sizes. Especially wide or tall images (ie. 2 x 3000) will cause this function to crash the application. But this would be better handled in Haneke itself by simply returning the original image.