### PR TITLE
fix tag name typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,3 +246,4 @@ Haneke Swift is in initial development and its public API should not be consider
  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  See the License for the specific language governing permissions and
  limitations under the License.
+


### PR DESCRIPTION
typo tag name?

original:`0.11.0`
fixed:`v0.11.0`

Because I did not know how to change tags only, I inserted a blank line in README.md and committed it