### PR TITLE
Basic config object allowing disk path to be configured

### DIFF
--- a/Haneke/DiskCache.swift
+++ b/Haneke/DiskCache.swift
@@ -11,8 +11,8 @@ import Foundation
 open class DiskCache {
     
     open class func basePath() -> String {
-        let cachesPath = NSSearchPathForDirectoriesInDomains(FileManager.SearchPathDirectory.cachesDirectory, FileManager.SearchPathDomainMask.userDomainMask, true)[0]
-        let hanekePathComponent = HanekeGlobals.Domain
+        let cachesPath = HanekeGlobals.config.cacheRootPath
+        let hanekePathComponent = HanekeGlobals.config.domain
         let basePath = (cachesPath as NSString).appendingPathComponent(hanekePathComponent)
         // TODO: Do not recaculate basePath value
         return basePath
@@ -31,7 +31,7 @@ open class DiskCache {
     }
 
     open lazy var cacheQueue : DispatchQueue = {
-        let queueName = HanekeGlobals.Domain + "." + (self.path as NSString).lastPathComponent
+        let queueName = HanekeGlobals.config.domain + "." + (self.path as NSString).lastPathComponent
         let cacheQueue = DispatchQueue(label: queueName, attributes: [])
         return cacheQueue
     }()

--- a/Haneke/Haneke.swift
+++ b/Haneke/Haneke.swift
@@ -8,9 +8,22 @@
 
 import UIKit
 
+public struct Config {
+    public let domain: String
+    public let cacheRootPath: String
+
+    public init(domain: String, cacheRootPath: String) {
+        self.domain = domain
+        self.cacheRootPath = cacheRootPath
+    }
+}
+
 public struct HanekeGlobals {
     
-    public static let Domain = "io.haneke"
+    public static var config = Config(
+        domain: "io.haneke",
+        cacheRootPath: NSSearchPathForDirectoriesInDomains(FileManager.SearchPathDirectory.cachesDirectory, FileManager.SearchPathDomainMask.userDomainMask, true)[0]
+        )
     
 }
 
@@ -51,5 +64,5 @@ public struct Shared {
 
 func errorWithCode(_ code: Int, description: String) -> Error {
     let userInfo = [NSLocalizedDescriptionKey: description]
-    return NSError(domain: HanekeGlobals.Domain, code: code, userInfo: userInfo) as Error
+    return NSError(domain: HanekeGlobals.config.domain, code: code, userInfo: userInfo) as Error
 }


### PR DESCRIPTION
This commit moves the disk cache root path (and domain identifier) into a config object you can swap out in your app delegate. 

```
// in AppDelegate.swift
HanekeGlobals.config = Config(
    domain: "images",
    cacheRootPath: NSSearchPathForDirectoriesInDomains(FileManager.SearchPathDirectory.documentDirectory, FileManager.SearchPathDomainMask.userDomainMask, true)[0]
)
```

I have a use-case where the cacheable images and video clips are ephemeral and one purpose of the iOS app is to allow local persistence of the data. I also saw that other users has posed questions in this direction. E.g. https://github.com/Haneke/HanekeSwift/issues/423

I can also see my app wanting to expose these images to the Files app, which is why the domain identifier came along for the ride.

I am so impressed by the simplicity and performance of Haneke. I really wanted to keep getting the benefits of that while still providing persistent storage.


Thoughts?

