### PR TITLE
Add support for SwiftPM based dependency managers

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,16 @@
+// swift-tools-version:4.2
+import PackageDescription
+
+let package = Package(
+    name: "Haneke",
+    // platforms: [.iOS("8.0"), tvOS("9.1")],
+    products: [
+        .library(name: "Haneke", targets: ["Haneke"])
+    ],
+    targets: [
+        .target(
+            name: "Haneke",
+            path: "Haneke"
+        )
+    ]
+)

--- a/Package.swift
+++ b/Package.swift
@@ -1,16 +1,9 @@
-// swift-tools-version:4.2
+// swift-tools-version:5.0
 import PackageDescription
 
 let package = Package(
     name: "Haneke",
-    // platforms: [.iOS("8.0"), tvOS("9.1")],
-    products: [
-        .library(name: "Haneke", targets: ["Haneke"])
-    ],
-    targets: [
-        .target(
-            name: "Haneke",
-            path: "Haneke"
-        )
-    ]
+    platforms: [.iOS("8.0"), .tvOS("9.1")],
+    products: [.library(name: "Haneke", targets: ["Haneke"])],
+    targets: [.target(name: "Haneke", path: "Haneke")]
 )

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 ![Haneke](https://raw.githubusercontent.com/Haneke/HanekeSwift/master/Assets/github-header.png)
 
 [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
+[![SwiftPM compatible](https://img.shields.io/badge/SwiftPM-compatible-brightgreen.svg)](https://github.com/apple/swift-package-manager)
 [![Accio supported](https://img.shields.io/badge/Accio-supported-0A7CF5.svg?style=flat)](https://github.com/JamitLabs/Accio)
 [![Platform](https://cocoapod-badges.herokuapp.com/p/HanekeSwift/badge.png)](http://cocoadocs.org/docsets/HanekeSwift)
 [![Build Status](https://travis-ci.org/Haneke/HanekeSwift.svg?branch=master)](https://travis-ci.org/Haneke/HanekeSwift)
@@ -59,11 +60,11 @@ Using [Carthage](https://github.com/Carthage/Carthage):
 github "Haneke/HanekeSwift"
 ```
 
-Using [Accio](https://github.com/JamitLabs/Accio):
+Using [SwiftPM](https://github.com/apple/swift-package-manager) or [Accio](https://github.com/JamitLabs/Accio):
 
 
 ```swift
-.package(url: "https://github.com/Haneke/HanekeSwift.git", .upToNextMajor(from: "0.11.1")),
+.package(url: "https://github.com/Haneke/HanekeSwift.git", .upToNextMajor(from: "0.11.2")),
 ```
 
 Then link `Haneke` in your App target like so:
@@ -92,15 +93,15 @@ Manually:
 
 ## Using the cache
 
-Haneke provides shared caches for `UIImage`, `NSData`, `JSON` and `String`. You can also create your own caches. 
+Haneke provides shared caches for `UIImage`, `NSData`, `JSON` and `String`. You can also create your own caches.
 
 The cache is a key-value store. For example, here's how you would cache and then fetch some data.
 
 ```Swift
 let cache = Shared.dataCache
-        
+
 cache.set(value: data, key: "funny-games.mp4")
-        
+
 // Eventually...
 
 cache.fetch(key: "funny-games.mp4").onSuccess { data in
@@ -108,12 +109,12 @@ cache.fetch(key: "funny-games.mp4").onSuccess { data in
 }
 ```
 
-In most cases the value will not be readily available and will have to be fetched from network or disk. Haneke offers convenience `fetch` functions for these cases. Let's go back to the first example, now using a shared cache: 
+In most cases the value will not be readily available and will have to be fetched from network or disk. Haneke offers convenience `fetch` functions for these cases. Let's go back to the first example, now using a shared cache:
 
 ```Swift
 let cache = Shared.JSONCache
 let URL = NSURL(string: "https://api.github.com/users/haneke")!
-    
+
 cache.fetch(URL: URL).onSuccess { JSON in
    print(JSON.dictionary?["bio"])
 }
@@ -198,7 +199,7 @@ Through custom fetchers you can fetch original values from other sources than ne
 * Fetching the value in background and calling the success or failure closure accordingly, both in the main queue
 * Cancelling the fetch on demand, if possible
 
-Fetchers are generic, and the only restriction on their type is that it must implement `DataConvertible`. 
+Fetchers are generic, and the only restriction on their type is that it must implement `DataConvertible`.
 
 ## Supporting additional types
 
@@ -207,15 +208,15 @@ Haneke can cache any type that can be read and saved as data. This is indicated 
 ```Swift
 public protocol DataConvertible {
     typealias Result
-    
+
     class func convertFromData(data:NSData) -> Result?
-    
+
 }
 
 public protocol DataRepresentable {
-    
+
     func asData() -> NSData!
-    
+
 }
 ```
 
@@ -223,17 +224,17 @@ This is how one could add support for `NSDictionary`:
 
 ```Swift
 extension NSDictionary : DataConvertible, DataRepresentable {
-    
+
     public typealias Result = NSDictionary
-    
+
     public class func convertFromData(data:NSData) -> Result? {
         return NSKeyedUnarchiver.unarchiveObjectWithData(data) as? NSDictionary
     }
-    
+
     public func asData() -> NSData! {
         return NSKeyedArchiver.archivedDataWithRootObject(self)
     }
-    
+
 }
 ```
 
@@ -253,13 +254,13 @@ Haneke Swift is in initial development and its public API should not be consider
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;2014 Joan Romano ([@joanromano](https://twitter.com/joanromano))   
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;2014 Luis Ascorbe ([@lascorbe](https://twitter.com/Lascorbe))   
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;2014 Oriol Blanc ([@oriolblanc](https://twitter.com/oriolblanc))   
- 
+
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
  You may obtain a copy of the License at
- 
+
  http://www.apache.org/licenses/LICENSE-2.0
- 
+
  Unless required by applicable law or agreed to in writing, software
  distributed under the License is distributed on an "AS IS" BASIS,
  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 ![Haneke](https://raw.githubusercontent.com/Haneke/HanekeSwift/master/Assets/github-header.png)
 
 [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
+[![Accio supported](https://img.shields.io/badge/Accio-supported-0A7CF5.svg?style=flat)](https://github.com/JamitLabs/Accio)
 [![Platform](https://cocoapod-badges.herokuapp.com/p/HanekeSwift/badge.png)](http://cocoadocs.org/docsets/HanekeSwift)
 [![Build Status](https://travis-ci.org/Haneke/HanekeSwift.svg?branch=master)](https://travis-ci.org/Haneke/HanekeSwift)
 [![Join the chat at https://gitter.im/Haneke/HanekeSwift](https://badges.gitter.im/Haneke/HanekeSwift.svg)](https://gitter.im/Haneke/HanekeSwift?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
@@ -56,6 +57,24 @@ Using [Carthage](https://github.com/Carthage/Carthage):
 
 ```
 github "Haneke/HanekeSwift"
+```
+
+Using [Accio](https://github.com/JamitLabs/Accio):
+
+
+```swift
+.package(url: "https://github.com/Haneke/HanekeSwift.git", .upToNextMajor(from: "0.11.1")),
+```
+
+Then link `Haneke` in your App target like so:
+
+```swift
+.target(
+    name: "App",
+    dependencies: [
+        "Haneke",
+    ]
+),
 ```
 
 Manually:


### PR DESCRIPTION
This adds support for SwiftPM manifest based dependency managers. Specifically this adds support for installing via [Accio](https://github.com/JamitLabs/Accio) but will probably also work with SwiftPM once it's integrated into Xcode.

Please note that this project is part of Accio's official [integration tests](https://github.com/JamitLabs/Accio/tree/work/1000-frameworks/Demo/Shared/AppDependencies) within the [Demo project](https://github.com/JamitLabs/Accio/tree/work/1000-frameworks/Demo).