### PR TITLE
Create intermediate directories before writing to a file

### DIFF
--- a/Haneke/DiskCache.swift
+++ b/Haneke/DiskCache.swift
@@ -170,7 +170,16 @@ open class DiskCache {
         let path = self.path(forKey: key)
         let fileManager = FileManager.default
         let previousAttributes : [FileAttributeKey: Any]? = try? fileManager.attributesOfItem(atPath: path)
-        
+
+        //If the data folder does not exist, it needs to be recreated
+        if (!fileManager.fileExists(atPath: self.path)) {
+            do {
+                try fileManager.createDirectory(atPath: self.path, withIntermediateDirectories: true, attributes: nil)
+            } catch {
+                Log.error(message: "Failed to create directory", error: error)
+            }
+        }
+
         do {
             try data.write(to: URL(fileURLWithPath: path), options: Data.WritingOptions.atomicWrite)
         } catch {


### PR DESCRIPTION
This pull request makes sure, that before a file is written to the disk, the folders in the path it should be written to exists. All the needed intermediate directories are created, so that the data can be written to the file without failing due to a non existing directory.

Some already mentioned in #371 and #245, that after the `removeAll()` method of a cache is called, the folders are deleted, but not recreated directly. So the writes after calling `removeAll()` are failing with an error. 